### PR TITLE
Fix abyss command

### DIFF
--- a/MehrakCore/Services/Commands/Genshin/Abyss/GenshinAbyssCardService.cs
+++ b/MehrakCore/Services/Commands/Genshin/Abyss/GenshinAbyssCardService.cs
@@ -61,7 +61,9 @@ internal class GenshinAbyssCardService : ICommandService<GenshinAbyssCommandExec
         List<IDisposable> disposableResources = [];
         try
         {
-            var portraitImages = await abyssData.Floors!.SelectMany(x => x.Levels!.SelectMany(y => y.Battles!))
+            var floorData = abyssData.Floors!.First(x => x.Index == floor);
+
+            var portraitImages = await floorData.Levels!.SelectMany(y => y.Battles!)
                 .SelectMany(x => x.Avatars!).DistinctBy(x => x.Id).ToAsyncEnumerable().ToDictionaryAwaitAsync(
                     async x => await Task.FromResult(x),
                     async x => await Image.LoadAsync(
@@ -81,7 +83,6 @@ internal class GenshinAbyssCardService : ICommandService<GenshinAbyssCommandExec
             var background =
                 await Image.LoadAsync(await m_ImageRepository.DownloadFileToStreamAsync("genshin_abyss_bg"));
             disposableResources.Add(background);
-            var floorData = abyssData.Floors!.First(x => x.Index == floor);
 
             background.Mutate(ctx =>
             {


### PR DESCRIPTION
Fixes the following issues with the abyss command
- Abyss card service attempts to fetch images that are not guaranteed to be downloaded
- Abyss card service always shows max stars visually