### PR TITLE
Double auth error messages

### DIFF
--- a/MehrakCore.Tests/Services/Commands/Genshin/GenshinAbyssCommandExecutorTests.cs
+++ b/MehrakCore.Tests/Services/Commands/Genshin/GenshinAbyssCommandExecutorTests.cs
@@ -273,7 +273,7 @@ public class GenshinAbyssCommandExecutorTests
         // Assert
         m_LoggerMock.Verify(
             x => x.Log(
-                LogLevel.Error,
+                LogLevel.Warning,
                 It.IsAny<EventId>(),
                 It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Authentication failed")),
                 It.IsAny<Exception>(),

--- a/MehrakCore.Tests/Services/Commands/Genshin/GenshinCharacterCommandExecutorTests.cs
+++ b/MehrakCore.Tests/Services/Commands/Genshin/GenshinCharacterCommandExecutorTests.cs
@@ -465,17 +465,23 @@ public class GenshinCharacterCommandExecutorTests
     #region OnAuthenticationCompletedAsync Tests
 
     [Test]
-    public async Task OnAuthenticationCompletedAsync_WhenAuthenticationFails_SendsErrorMessage()
+    public async Task OnAuthenticationCompletedAsync_AuthenticationFailed_LogsError()
     {
         // Arrange
-        var authResult = AuthenticationResult.Failure(m_TestUserId, "Invalid passphrase");
+        var result = AuthenticationResult.Failure(m_TestUserId, "Authentication failed");
 
         // Act
-        await m_Executor.OnAuthenticationCompletedAsync(authResult);
+        await m_Executor.OnAuthenticationCompletedAsync(result);
 
         // Assert
-        var response = await m_DiscordTestHelper.ExtractInteractionResponseDataAsync();
-        Assert.That(response, Contains.Substring("Authentication failed: Invalid passphrase"));
+        m_LoggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Authentication failed")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
     }
 
     [Test]

--- a/MehrakCore.Tests/Services/Commands/Genshin/GenshinCodeRedeemExecutorTests.cs
+++ b/MehrakCore.Tests/Services/Commands/Genshin/GenshinCodeRedeemExecutorTests.cs
@@ -210,6 +210,26 @@ public class GenshinCodeRedeemExecutorTests
     }
 
     [Test]
+    public async Task OnAuthenticationCompletedAsync_AuthenticationFailed_LogsError()
+    {
+        // Arrange
+        var result = AuthenticationResult.Failure(m_TestUserId, "Authentication failed");
+
+        // Act
+        await m_Executor.OnAuthenticationCompletedAsync(result);
+
+        // Assert
+        m_LoggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Authentication failed")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Test]
     public async Task OnAuthenticationCompletedAsync_SuccessfulAuth_ShouldRedeemCode()
     {
         // Arrange
@@ -234,20 +254,6 @@ public class GenshinCodeRedeemExecutorTests
             It.IsAny<string>(),
             TestLtUid,
             TestLToken), Times.AtLeastOnce);
-    }
-
-    [Test]
-    public async Task OnAuthenticationCompletedAsync_FailedAuth_ShouldSendErrorResponse()
-    {
-        // Arrange
-        var authResult = AuthenticationResult.Failure(m_TestUserId, "Authentication failed");
-
-        // Act
-        await m_Executor.OnAuthenticationCompletedAsync(authResult);
-
-        // Assert
-        var response = await m_DiscordTestHelper.ExtractInteractionResponseDataAsync();
-        Assert.That(response, Does.Contain("Authentication failed"));
     }
 
     [Test]

--- a/MehrakCore.Tests/Services/Commands/Genshin/GenshinRealTimeNotesCommandExecutorTests.cs
+++ b/MehrakCore.Tests/Services/Commands/Genshin/GenshinRealTimeNotesCommandExecutorTests.cs
@@ -331,6 +331,26 @@ public class GenshinRealTimeNotesCommandExecutorTests
     }
 
     [Test]
+    public async Task OnAuthenticationCompletedAsync_AuthenticationFailed_LogsError()
+    {
+        // Arrange
+        var result = AuthenticationResult.Failure(m_TestUserId, "Authentication failed");
+
+        // Act
+        await m_Executor.OnAuthenticationCompletedAsync(result);
+
+        // Assert
+        m_LoggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Authentication failed")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Test]
     public async Task OnAuthenticationCompletedAsync_WithSuccessfulResult_FetchesNotesAndSendsCard()
     {
         // Arrange
@@ -365,20 +385,6 @@ public class GenshinRealTimeNotesCommandExecutorTests
 
         m_ApiServiceMock.Verify(x => x.GetRealTimeNotesAsync(
             It.IsAny<string>(), It.IsAny<string>(), TestLtUid, TestLToken), Times.Once);
-    }
-
-    [Test]
-    public async Task OnAuthenticationCompletedAsync_WithFailedResult_SendsErrorMessage()
-    {
-        // Arrange
-        var result = AuthenticationResult.Failure(m_TestUserId, "Invalid authentication token");
-
-        // Act
-        await m_Executor.OnAuthenticationCompletedAsync(result);
-
-        // Assert
-        var response = await m_DiscordTestHelper.ExtractInteractionResponseDataAsync();
-        Assert.That(response, Contains.Substring("authentication") | Contains.Substring("error"));
     }
 
     #endregion

--- a/MehrakCore.Tests/Services/Commands/Genshin/GenshinStygianCommandExecutorTests.cs
+++ b/MehrakCore.Tests/Services/Commands/Genshin/GenshinStygianCommandExecutorTests.cs
@@ -735,25 +735,21 @@ public class GenshinStygianCommandExecutorTests
     }
 
     [Test]
-    public async Task OnAuthenticationCompletedAsync_WithFailedAuth_SendsErrorMessage()
+    public async Task OnAuthenticationCompletedAsync_AuthenticationFailed_LogsError()
     {
         // Arrange
-        var authResult = AuthenticationResult.Failure(m_TestUserId, "Authentication failed");
+        var result = AuthenticationResult.Failure(m_TestUserId, "Authentication failed");
 
         // Act
-        await m_Executor.OnAuthenticationCompletedAsync(authResult);
+        await m_Executor.OnAuthenticationCompletedAsync(result);
 
         // Assert
-        var responseMessage = await m_DiscordTestHelper.ExtractInteractionResponseDataAsync();
-        Assert.That(responseMessage, Does.Contain("Authentication failed"));
-
-        // Verify error was logged
         m_LoggerMock.Verify(
             x => x.Log(
-                LogLevel.Error,
+                LogLevel.Warning,
                 It.IsAny<EventId>(),
                 It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Authentication failed")),
-                It.IsAny<Exception>(),
+                It.IsAny<Exception?>(),
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once);
     }

--- a/MehrakCore.Tests/Services/Commands/Genshin/GenshinTheaterCommandExecutorTests.cs
+++ b/MehrakCore.Tests/Services/Commands/Genshin/GenshinTheaterCommandExecutorTests.cs
@@ -356,7 +356,7 @@ public class GenshinTheaterCommandExecutorTests
     #region OnAuthenticationCompletedAsync Tests
 
     [Test]
-    public async Task OnAuthenticationCompletedAsync_AuthenticationFailed_LogsErrorAndSendsMessage()
+    public async Task OnAuthenticationCompletedAsync_AuthenticationFailed_LogsError()
     {
         // Arrange
         var result = AuthenticationResult.Failure(m_TestUserId, "Authentication failed");
@@ -373,9 +373,6 @@ public class GenshinTheaterCommandExecutorTests
                 It.IsAny<Exception?>(),
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once);
-
-        var responseContent = await m_DiscordTestHelper.ExtractInteractionResponseDataAsync();
-        Assert.That(responseContent, Does.Contain("Authentication failed"));
     }
 
     [Test]

--- a/MehrakCore.Tests/Services/Commands/Hsr/HsrBossChallengeCommandExecutorTests.cs
+++ b/MehrakCore.Tests/Services/Commands/Hsr/HsrBossChallengeCommandExecutorTests.cs
@@ -492,6 +492,26 @@ public class HsrBossChallengeCommandExecutorTests
     #region OnAuthenticationCompletedAsync Tests
 
     [Test]
+    public async Task OnAuthenticationCompletedAsync_AuthenticationFailed_LogsError()
+    {
+        // Arrange
+        var result = AuthenticationResult.Failure(m_TestUserId, "Authentication failed");
+
+        // Act
+        await m_Executor.OnAuthenticationCompletedAsync(result);
+
+        // Assert
+        m_LoggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Authentication failed")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Test]
     public async Task OnAuthenticationCompletedAsync_SuccessfulAuth_ContinuesExecution()
     {
         // Arrange
@@ -511,26 +531,6 @@ public class HsrBossChallengeCommandExecutorTests
         // Assert
         var response = await m_DiscordTestHelper.ExtractInteractionResponseDataAsync();
         Assert.That(response, Is.Not.Null);
-    }
-
-    [Test]
-    public async Task OnAuthenticationCompletedAsync_FailedAuth_SendsErrorMessage()
-    {
-        // Arrange
-        await CreateTestUserAsync();
-
-        // Set pending parameters first
-        SetupTokenCacheEmpty();
-        await m_Executor.ExecuteAsync(Regions.America, TestProfileId);
-
-        var authResult = AuthenticationResult.Failure(m_TestUserId, "Authentication failed");
-
-        // Act
-        await m_Executor.OnAuthenticationCompletedAsync(authResult);
-
-        // Assert
-        var response = await m_DiscordTestHelper.ExtractInteractionResponseDataAsync();
-        Assert.That(response, Does.Contain("Authentication failed"));
     }
 
     [Test]

--- a/MehrakCore.Tests/Services/Commands/Hsr/HsrCharacterCommandExecutorTests.cs
+++ b/MehrakCore.Tests/Services/Commands/Hsr/HsrCharacterCommandExecutorTests.cs
@@ -448,20 +448,6 @@ public class HsrCharacterCommandExecutorTests
     #region OnAuthenticationCompletedAsync Tests
 
     [Test]
-    public async Task OnAuthenticationCompletedAsync_WhenAuthenticationFails_SendsErrorMessage()
-    {
-        // Arrange
-        var authResult = AuthenticationResult.Failure(m_TestUserId, "Authentication failed");
-
-        // Act
-        await m_Executor.OnAuthenticationCompletedAsync(authResult);
-
-        // Assert
-        var response = await m_DiscordTestHelper.ExtractInteractionResponseDataAsync();
-        Assert.That(response, Contains.Substring("Authentication failed"));
-    }
-
-    [Test]
     public async Task
         OnAuthenticationCompletedAsync_WhenAuthenticationSucceedsWithValidParameters_CallsSendCharacterCard()
     {

--- a/MehrakCore.Tests/Services/Commands/Hsr/HsrCodeRedeemExecutorTests.cs
+++ b/MehrakCore.Tests/Services/Commands/Hsr/HsrCodeRedeemExecutorTests.cs
@@ -274,6 +274,27 @@ public class HsrCodeRedeemExecutorTests
         Assert.That(response, Is.Not.Null);
     }
 
+
+    [Test]
+    public async Task OnAuthenticationCompletedAsync_AuthenticationFailed_LogsError()
+    {
+        // Arrange
+        var result = AuthenticationResult.Failure(m_TestUserId, "Authentication failed");
+
+        // Act
+        await m_Executor.OnAuthenticationCompletedAsync(result);
+
+        // Assert
+        m_LoggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Authentication failed")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
     [Test]
     public async Task OnAuthenticationCompletedAsync_SuccessfulAuth_ShouldRedeemCode()
     {
@@ -300,20 +321,6 @@ public class HsrCodeRedeemExecutorTests
             It.IsAny<string>(),
             TestLtUid,
             TestLToken), Times.Once);
-    }
-
-    [Test]
-    public async Task OnAuthenticationCompletedAsync_FailedAuth_ShouldSendErrorResponse()
-    {
-        // Arrange
-        var authResult = AuthenticationResult.Failure(m_TestUserId, "Authentication failed");
-
-        // Act
-        await m_Executor.OnAuthenticationCompletedAsync(authResult);
-
-        // Assert
-        var response = await m_DiscordTestHelper.ExtractInteractionResponseDataAsync();
-        Assert.That(response, Does.Contain("Authentication failed"));
     }
 
     [Test]

--- a/MehrakCore.Tests/Services/Commands/Hsr/HsrMemoryCommandExecutorTests.cs
+++ b/MehrakCore.Tests/Services/Commands/Hsr/HsrMemoryCommandExecutorTests.cs
@@ -411,25 +411,21 @@ public class HsrMemoryCommandExecutorTests
     #region OnAuthenticationCompletedAsync Tests
 
     [Test]
-    public async Task OnAuthenticationCompletedAsync_AuthenticationFailed_LogsErrorAndSendsMessage()
+    public async Task OnAuthenticationCompletedAsync_AuthenticationFailed_LogsError()
     {
         // Arrange
-        var authResult = AuthenticationResult.Failure(m_TestUserId, "Authentication failed");
+        var result = AuthenticationResult.Failure(m_TestUserId, "Authentication failed");
 
         // Act
-        await m_Executor.OnAuthenticationCompletedAsync(authResult);
+        await m_Executor.OnAuthenticationCompletedAsync(result);
 
         // Assert
-        var responseContent = await m_DiscordTestHelper.ExtractInteractionResponseDataAsync();
-        Assert.That(responseContent, Does.Contain("Authentication failed"));
-
-        // Verify error was logged
         m_LoggerMock.Verify(
             x => x.Log(
-                LogLevel.Error,
+                LogLevel.Warning,
                 It.IsAny<EventId>(),
                 It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Authentication failed")),
-                It.IsAny<Exception>(),
+                It.IsAny<Exception?>(),
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once);
     }

--- a/MehrakCore.Tests/Services/Commands/Hsr/HsrPureFictionCommandExecutorTests.cs
+++ b/MehrakCore.Tests/Services/Commands/Hsr/HsrPureFictionCommandExecutorTests.cs
@@ -459,26 +459,6 @@ public class HsrPureFictionCommandExecutorTests
     }
 
     [Test]
-    public async Task OnAuthenticationCompletedAsync_FailedAuth_SendsErrorMessage()
-    {
-        // Arrange
-        await CreateTestUserAsync();
-
-        // Set pending parameters first
-        SetupTokenCacheEmpty();
-        await m_Executor.ExecuteAsync(Regions.America, TestProfileId);
-
-        var authResult = AuthenticationResult.Failure(m_TestUserId, "Authentication failed");
-
-        // Act
-        await m_Executor.OnAuthenticationCompletedAsync(authResult);
-
-        // Assert
-        var response = await m_DiscordTestHelper.ExtractInteractionResponseDataAsync();
-        Assert.That(response, Does.Contain("Authentication failed"));
-    }
-
-    [Test]
     public async Task OnAuthenticationCompletedAsync_UserNotFoundAfterAuth_ShouldSendErrorResponse()
     {
         // Arrange
@@ -499,6 +479,26 @@ public class HsrPureFictionCommandExecutorTests
         // Assert
         var response = await m_DiscordTestHelper.ExtractInteractionResponseDataAsync();
         Assert.That(response, Does.Contain("No profile found. Please select the correct profile"));
+    }
+
+    [Test]
+    public async Task OnAuthenticationCompletedAsync_AuthenticationFailed_LogsError()
+    {
+        // Arrange
+        var result = AuthenticationResult.Failure(m_TestUserId, "Authentication failed");
+
+        // Act
+        await m_Executor.OnAuthenticationCompletedAsync(result);
+
+        // Assert
+        m_LoggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Authentication failed")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
     }
 
     [Test]

--- a/MehrakCore.Tests/Services/Commands/Hsr/HsrRealTimeNotesCommandExecutorTests.cs
+++ b/MehrakCore.Tests/Services/Commands/Hsr/HsrRealTimeNotesCommandExecutorTests.cs
@@ -379,6 +379,26 @@ public class HsrRealTimeNotesCommandExecutorTests
     #region OnAuthenticationCompletedAsync Tests
 
     [Test]
+    public async Task OnAuthenticationCompletedAsync_AuthenticationFailed_LogsError()
+    {
+        // Arrange
+        var result = AuthenticationResult.Failure(m_TestUserId, "Authentication failed");
+
+        // Act
+        await m_Executor.OnAuthenticationCompletedAsync(result);
+
+        // Assert
+        m_LoggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Authentication failed")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Test]
     public async Task OnAuthenticationCompletedAsync_WhenAuthenticationSuccessful_SendsRealTimeNotes()
     {
         // Arrange
@@ -407,20 +427,6 @@ public class HsrRealTimeNotesCommandExecutorTests
         // Assert
         m_ApiServiceMock.Verify(x => x.GetRealTimeNotesAsync(
             It.IsAny<string>(), It.IsAny<string>(), TestLtUid, TestLToken), Times.AtLeastOnce);
-    }
-
-    [Test]
-    public async Task OnAuthenticationCompletedAsync_WhenAuthenticationFailed_SendsErrorResponse()
-    {
-        // Arrange
-        var authResult = AuthenticationResult.Failure(m_TestUserId, "Authentication failed");
-
-        // Act
-        await m_Executor.OnAuthenticationCompletedAsync(authResult);
-
-        // Assert
-        var response = await m_DiscordTestHelper.ExtractInteractionResponseDataAsync();
-        Assert.That(response, Contains.Substring("Authentication failed: Authentication failed"));
     }
 
     #endregion

--- a/MehrakCore.Tests/Services/Commands/Zzz/ZzzCodeRedeemExecutorTests.cs
+++ b/MehrakCore.Tests/Services/Commands/Zzz/ZzzCodeRedeemExecutorTests.cs
@@ -303,20 +303,6 @@ public class ZzzCodeRedeemExecutorTests
     }
 
     [Test]
-    public async Task OnAuthenticationCompletedAsync_FailedAuth_ShouldSendErrorResponse()
-    {
-        // Arrange
-        var authResult = AuthenticationResult.Failure(m_TestUserId, "Authentication failed");
-
-        // Act
-        await m_Executor.OnAuthenticationCompletedAsync(authResult);
-
-        // Assert
-        var response = await m_DiscordTestHelper.ExtractInteractionResponseDataAsync();
-        Assert.That(response, Does.Contain("Authentication failed"));
-    }
-
-    [Test]
     public async Task ExecuteAsync_GameRecordApiFails_ShouldSendErrorResponse()
     {
         // Arrange
@@ -652,6 +638,26 @@ public class ZzzCodeRedeemExecutorTests
         // Assert
         var response = await m_DiscordTestHelper.ExtractInteractionResponseDataAsync();
         Assert.That(response, Does.Contain("Redemption Code Expired"));
+    }
+
+    [Test]
+    public async Task OnAuthenticationCompletedAsync_AuthenticationFailed_LogsError()
+    {
+        // Arrange
+        var result = AuthenticationResult.Failure(m_TestUserId, "Authentication failed");
+
+        // Act
+        await m_Executor.OnAuthenticationCompletedAsync(result);
+
+        // Assert
+        m_LoggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Authentication failed")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
     }
 
     [Test]

--- a/MehrakCore/Modules/Common/AuthModalModule.cs
+++ b/MehrakCore/Modules/Common/AuthModalModule.cs
@@ -151,7 +151,7 @@ public class AuthModalModule : ComponentInteractionModule<ModalInteractionContex
                 m_Logger.LogWarning("User {UserId} not found in database", Context.User.Id);
                 await Context.Interaction.SendFollowupMessageAsync(new InteractionMessageProperties()
                     .WithFlags(MessageFlags.Ephemeral | MessageFlags.IsComponentsV2)
-                    .WithComponents([new TextDisplayProperties("No profile found! Please add a profile first.")]));
+                    .WithComponents([new TextDisplayProperties("No profile found! Please add a profile first")]));
                 return AuthenticationResult.Failure(Context.User.Id, "No profile found");
             }
 
@@ -174,7 +174,7 @@ public class AuthModalModule : ComponentInteractionModule<ModalInteractionContex
                         .OriginalResponseMessageId!.Value);
             await Context.Interaction.SendFollowupMessageAsync(new InteractionMessageProperties()
                 .WithFlags(MessageFlags.Ephemeral | MessageFlags.IsComponentsV2)
-                .WithComponents([new TextDisplayProperties("Invalid passphrase. Please try again.")]));
+                .WithComponents([new TextDisplayProperties("Invalid passphrase. Please try again")]));
             return AuthenticationResult.Failure(Context.User.Id, "Invalid passphrase");
         }
         catch (Exception e)
@@ -184,7 +184,7 @@ public class AuthModalModule : ComponentInteractionModule<ModalInteractionContex
             await Context.Interaction.SendResponseAsync(InteractionCallback.Message(new InteractionMessageProperties()
                 .WithFlags(MessageFlags.Ephemeral | MessageFlags.IsComponentsV2)
                 .AddComponents(
-                    new TextDisplayProperties("An error occurred during authentication. Please try again later."))));
+                    new TextDisplayProperties("An error occurred during authentication. Please try again later"))));
             return AuthenticationResult.Failure(Context.User.Id, "An error occurred during authentication");
         }
     }

--- a/MehrakCore/Services/Commands/Common/DailyCheckInCommandExecutor.cs
+++ b/MehrakCore/Services/Commands/Common/DailyCheckInCommandExecutor.cs
@@ -113,7 +113,6 @@ public class DailyCheckInCommandExecutor : BaseCommandExecutor<DailyCheckInComma
             {
                 Logger.LogWarning("Authentication failed for user {UserId}: {ErrorMessage}",
                     result.UserId, result.ErrorMessage);
-                await SendAuthenticationErrorAsync(result.ErrorMessage);
                 return;
             }
 

--- a/MehrakCore/Services/Commands/Executor/BaseCommandExecutor.cs
+++ b/MehrakCore/Services/Commands/Executor/BaseCommandExecutor.cs
@@ -245,7 +245,7 @@ public abstract class BaseCommandExecutor<TLogger> : ICommandExecutor, IAuthenti
             {
                 if (result.StatusCode == HttpStatusCode.Unauthorized)
                 {
-                    await SendAuthenticationErrorAsync(
+                    await SendErrorMessageAsync(
                         "Invalid HoYoLAB UID or Cookies. Please authenticate again");
                     return result;
                 }
@@ -280,16 +280,6 @@ public abstract class BaseCommandExecutor<TLogger> : ICommandExecutor, IAuthenti
         {
             throw new CommandException("An error occurred while updating user data", e);
         }
-    }
-
-    /// <summary>
-    /// Sends an error response for authentication failures.
-    /// </summary>
-    protected async Task SendAuthenticationErrorAsync(string errorMessage)
-    {
-        await Context.Interaction.SendFollowupMessageAsync(new InteractionMessageProperties()
-            .AddComponents(new TextDisplayProperties($"Authentication failed: {errorMessage}"))
-            .WithFlags(MessageFlags.Ephemeral | MessageFlags.IsComponentsV2));
     }
 
     /// <summary>

--- a/MehrakCore/Services/Commands/Genshin/Abyss/GenshinAbyssCommandExecutor.cs
+++ b/MehrakCore/Services/Commands/Genshin/Abyss/GenshinAbyssCommandExecutor.cs
@@ -92,9 +92,8 @@ public class GenshinAbyssCommandExecutor : BaseCommandExecutor<GenshinCommandMod
     {
         if (!result.IsSuccess)
         {
-            Logger.LogError("Authentication failed for user {UserId}: {ErrorMessage}", Context.Interaction.User.Id,
+            Logger.LogWarning("Authentication failed for user {UserId}: {ErrorMessage}", Context.Interaction.User.Id,
                 result.ErrorMessage);
-            await SendAuthenticationErrorAsync(result.ErrorMessage);
             return;
         }
 

--- a/MehrakCore/Services/Commands/Genshin/CharList/GenshinCharListCommandExecutor.cs
+++ b/MehrakCore/Services/Commands/Genshin/CharList/GenshinCharListCommandExecutor.cs
@@ -81,9 +81,8 @@ public class GenshinCharListCommandExecutor : BaseCommandExecutor<GenshinCommand
     {
         if (!result.IsSuccess)
         {
-            Logger.LogError("Authentication failed for user {UserId}: {ErrorMessage}", Context.Interaction.User.Id,
+            Logger.LogWarning("Authentication failed for user {UserId}: {ErrorMessage}", Context.Interaction.User.Id,
                 result.ErrorMessage);
-            await SendAuthenticationErrorAsync(result.ErrorMessage);
             return;
         }
 

--- a/MehrakCore/Services/Commands/Genshin/Character/GenshinCharacterCommandExecutor.cs
+++ b/MehrakCore/Services/Commands/Genshin/Character/GenshinCharacterCommandExecutor.cs
@@ -105,7 +105,6 @@ public class GenshinCharacterCommandExecutor : BaseCommandExecutor<GenshinCharac
         {
             Logger.LogWarning("Authentication failed for user {UserId}: {ErrorMessage}",
                 result.UserId, result.ErrorMessage);
-            await SendAuthenticationErrorAsync(result.ErrorMessage);
             return;
         }
 

--- a/MehrakCore/Services/Commands/Genshin/CodeRedeem/GenshinCodeRedeemExecutor.cs
+++ b/MehrakCore/Services/Commands/Genshin/CodeRedeem/GenshinCodeRedeemExecutor.cs
@@ -99,7 +99,6 @@ public class GenshinCodeRedeemExecutor : BaseCommandExecutor<GenshinCommandModul
         {
             Logger.LogWarning("Authentication failed for user {UserId}: {ErrorMessage}",
                 result.UserId, result.ErrorMessage);
-            await SendAuthenticationErrorAsync(result.ErrorMessage);
             return;
         }
 

--- a/MehrakCore/Services/Commands/Genshin/RealTimeNotes/GenshinRealTimeNotesCommandExecutor.cs
+++ b/MehrakCore/Services/Commands/Genshin/RealTimeNotes/GenshinRealTimeNotesCommandExecutor.cs
@@ -89,7 +89,6 @@ public class GenshinRealTimeNotesCommandExecutor : BaseCommandExecutor<GenshinRe
         {
             Logger.LogWarning("Authentication failed for user {UserId}: {ErrorMessage}",
                 Context.Interaction.User.Id, result.ErrorMessage);
-            await SendAuthenticationErrorAsync(result.ErrorMessage);
         }
     }
 

--- a/MehrakCore/Services/Commands/Genshin/Stygian/GenshinStygianCommandExecutor.cs
+++ b/MehrakCore/Services/Commands/Genshin/Stygian/GenshinStygianCommandExecutor.cs
@@ -82,9 +82,8 @@ public class GenshinStygianCommandExecutor : BaseCommandExecutor<GenshinCommandM
     {
         if (!result.IsSuccess)
         {
-            Logger.LogError("Authentication failed for user {UserId}: {ErrorMessage}", Context.Interaction.User.Id,
+            Logger.LogWarning("Authentication failed for user {UserId}: {ErrorMessage}", Context.Interaction.User.Id,
                 result.ErrorMessage);
-            await SendAuthenticationErrorAsync(result.ErrorMessage);
             return;
         }
 

--- a/MehrakCore/Services/Commands/Genshin/Theater/GenshinTheaterCommandExecutor.cs
+++ b/MehrakCore/Services/Commands/Genshin/Theater/GenshinTheaterCommandExecutor.cs
@@ -85,7 +85,6 @@ public class GenshinTheaterCommandExecutor : BaseCommandExecutor<GenshinCommandM
         {
             Logger.LogError("Authentication failed for user {UserId}: {ErrorMessage}", Context.Interaction.User.Id,
                 result.ErrorMessage);
-            await SendAuthenticationErrorAsync(result.ErrorMessage);
             return;
         }
 

--- a/MehrakCore/Services/Commands/Hsr/Character/HsrCharacterCommandExecutor.cs
+++ b/MehrakCore/Services/Commands/Hsr/Character/HsrCharacterCommandExecutor.cs
@@ -177,7 +177,6 @@ public class HsrCharacterCommandExecutor : BaseCommandExecutor<HsrCharacterComma
         {
             Logger.LogWarning("Authentication failed for user {UserId}: {ErrorMessage}",
                 Context.Interaction.User.Id, result.ErrorMessage);
-            await SendAuthenticationErrorAsync(result.ErrorMessage);
         }
     }
 

--- a/MehrakCore/Services/Commands/Hsr/CodeRedeem/HsrCodeRedeemExecutor.cs
+++ b/MehrakCore/Services/Commands/Hsr/CodeRedeem/HsrCodeRedeemExecutor.cs
@@ -98,7 +98,6 @@ public class HsrCodeRedeemExecutor : BaseCommandExecutor<HsrCommandModule>,
         {
             Logger.LogWarning("Authentication failed for user {UserId}: {ErrorMessage}",
                 result.UserId, result.ErrorMessage);
-            await SendAuthenticationErrorAsync(result.ErrorMessage);
             return;
         }
 

--- a/MehrakCore/Services/Commands/Hsr/EndGame/BossChallenge/HsrBossChallengeCommandExecutor.cs
+++ b/MehrakCore/Services/Commands/Hsr/EndGame/BossChallenge/HsrBossChallengeCommandExecutor.cs
@@ -84,9 +84,8 @@ public class HsrBossChallengeCommandExecutor : BaseHsrEndGameCommandExecutor
     {
         if (!result.IsSuccess)
         {
-            Logger.LogError("Authentication failed for user {UserId}: {ErrorMessage}", Context.Interaction.User.Id,
+            Logger.LogWarning("Authentication failed for user {UserId}: {ErrorMessage}", Context.Interaction.User.Id,
                 result.ErrorMessage);
-            await SendAuthenticationErrorAsync(result.ErrorMessage);
             return;
         }
 

--- a/MehrakCore/Services/Commands/Hsr/EndGame/PureFiction/HsrPureFictionCommandExecutor.cs
+++ b/MehrakCore/Services/Commands/Hsr/EndGame/PureFiction/HsrPureFictionCommandExecutor.cs
@@ -85,9 +85,8 @@ public class HsrPureFictionCommandExecutor : BaseHsrEndGameCommandExecutor
     {
         if (!result.IsSuccess)
         {
-            Logger.LogError("Authentication failed for user {UserId}: {ErrorMessage}", Context.Interaction.User.Id,
+            Logger.LogWarning("Authentication failed for user {UserId}: {ErrorMessage}", Context.Interaction.User.Id,
                 result.ErrorMessage);
-            await SendAuthenticationErrorAsync(result.ErrorMessage);
             return;
         }
 

--- a/MehrakCore/Services/Commands/Hsr/Memory/HsrMemoryCommandExecutor.cs
+++ b/MehrakCore/Services/Commands/Hsr/Memory/HsrMemoryCommandExecutor.cs
@@ -86,9 +86,8 @@ public class HsrMemoryCommandExecutor : BaseCommandExecutor<HsrCommandModule>
     {
         if (!result.IsSuccess)
         {
-            Logger.LogError("Authentication failed for user {UserId}: {ErrorMessage}", Context.Interaction.User.Id,
+            Logger.LogWarning("Authentication failed for user {UserId}: {ErrorMessage}", Context.Interaction.User.Id,
                 result.ErrorMessage);
-            await SendAuthenticationErrorAsync(result.ErrorMessage);
             return;
         }
 

--- a/MehrakCore/Services/Commands/Hsr/RealTimeNotes/HsrRealTimeNotesCommandExecutor.cs
+++ b/MehrakCore/Services/Commands/Hsr/RealTimeNotes/HsrRealTimeNotesCommandExecutor.cs
@@ -94,7 +94,6 @@ public class HsrRealTimeNotesCommandExecutor : BaseCommandExecutor<HsrRealTimeNo
         {
             Logger.LogWarning("Authentication failed for user {UserId}: {ErrorMessage}",
                 Context.Interaction.User.Id, result.ErrorMessage);
-            await SendAuthenticationErrorAsync(result.ErrorMessage);
         }
     }
 

--- a/MehrakCore/Services/Commands/Zzz/CodeRedeem/ZzzCodeRedeemExecutor.cs
+++ b/MehrakCore/Services/Commands/Zzz/CodeRedeem/ZzzCodeRedeemExecutor.cs
@@ -97,7 +97,6 @@ public class ZzzCodeRedeemExecutor : BaseCommandExecutor<ZzzCommandModule>, ICod
         {
             Logger.LogWarning("Authentication failed for user {UserId}: {ErrorMessage}",
                 result.UserId, result.ErrorMessage);
-            await SendAuthenticationErrorAsync(result.ErrorMessage);
             return;
         }
 


### PR DESCRIPTION
- Fixed an issue whereby authentication error messages will be sent twice
- Standardised internal logging severity for auth errors