### PR TITLE
HSR character card fail for Remembrance characters

### DIFF
--- a/MehrakBot/Mehrak.Application/Services/Hsr/Character/HsrCharacterApplicationService.cs
+++ b/MehrakBot/Mehrak.Application/Services/Hsr/Character/HsrCharacterApplicationService.cs
@@ -184,6 +184,14 @@ public class HsrCharacterApplicationService : BaseApplicationService<HsrCharacte
 
             tasks.AddRange(characterInfo.Skills.Select(x => m_ImageUpdaterService.UpdateImageAsync(x.ToImageData(),
                 new ImageProcessorBuilder().Resize(x.PointType == 1 ? 50 : 80, 0).Build())));
+
+            if (characterInfo.ServantDetail != null)
+            {
+                tasks.AddRange(characterInfo.ServantDetail.ServantSkills?.Select(x =>
+                    m_ImageUpdaterService.UpdateImageAsync(x.ToImageData(),
+                        new ImageProcessorBuilder().Resize(80, 0).Build())) ?? []);
+            }
+
             tasks.AddRange(characterInfo.Ranks.Select(x => m_ImageUpdaterService.UpdateImageAsync(x.ToImageData(),
                 new ImageProcessorBuilder().Resize(80, 0).Build())));
 


### PR DESCRIPTION
Fixed an issue whereby HSR Character command did not fetch Memosprite skill icons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Servant skill images are now automatically processed and included in character profile updates alongside related character data, ensuring consistent visual formatting and presentation across all character elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->