### PR TITLE
Draw centered icon extensions

### DIFF
--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Hsr/Anomaly/HsrAnomalyCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Hsr/Anomaly/HsrAnomalyCardServiceTests.cs
@@ -88,7 +88,7 @@ internal class HsrAnomalyCardServiceTests
 
         await using var image = await m_Service.GetCardAsync(cardContext);
 
-        using var fileStream = File.OpenWrite(Path.Combine(TestAssetsPath, goldenImage));
+        using var fileStream = File.Create(Path.Combine(TestAssetsPath, goldenImage));
         await image.CopyToAsync(fileStream);
         await fileStream.FlushAsync();
     }

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Hsr/Character/HsrCharacterCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Hsr/Character/HsrCharacterCardServiceTests.cs
@@ -193,7 +193,9 @@ public class HsrCharacterCardServiceTests
         await generatedImageStream.CopyToAsync(memoryStream);
 
         var outputPath = Path.Combine(AppContext.BaseDirectory, "Assets", "Hsr", "TestAssets", goldenImageFileName);
-        await File.WriteAllBytesAsync(outputPath, memoryStream.ToArray());
+        await using var fs = File.Create(outputPath);
+        await fs.WriteAsync(memoryStream.ToArray());
+        await fs.FlushAsync();
 
         Assert.That(generatedImageStream, Is.Not.Null);
     }

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Hsr/EndGame/HsrEndGameCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Hsr/EndGame/HsrEndGameCardServiceTests.cs
@@ -138,47 +138,57 @@ public class HsrEndGameCardServiceTests
         };
     }
 
-    // [Test]
-    // [TestCase("Pf_TestData_1.json", "Pf_GoldenImage_1.jpg")]
-    // [TestCase("Pf_TestData_2.json", "Pf_GoldenImage_2.jpg")]
-    // [TestCase("Pf_TestData_3.json", "Pf_GoldenImage_3.jpg")]
-    // public async Task GeneratePureFictionGoldenImage(string testDataFileName, string goldenImageFileName)
-    // {
-    //  HsrEndInformation? testData = await JsonSerializer.DeserializeAsync<HsrEndInformation>(
-    //         File.OpenRead(Path.Combine(AppContext.BaseDirectory, "TestData", "Hsr", testDataFileName)));
-    //     Assert.That(testData, Is.Not.Null);
-    //
-    //     GameProfileDto userGameData = GetTestUserGameData();
-    //
-    //   Stream image = await m_Service.GetCardAsync(
-    //         new HsrEndGameGenerationContext(TestUserId, testData!, Server.Asia, userGameData, HsrEndGameMode.PureFiction));
-    //
-    //     await using FileStream fileStream = File.Create(Path.Combine(AppContext.BaseDirectory, "Assets", "Hsr",
-    //         "TestAssets", goldenImageFileName));
-    //     await image.CopyToAsync(fileStream);
-    //
-    //     Assert.That(image, Is.Not.Null);
-    // }
+    [Explicit]
+    [Test]
+    [TestCase("Pf_TestData_1.json", "Pf_GoldenImage_1.jpg")]
+    [TestCase("Pf_TestData_2.json", "Pf_GoldenImage_2.jpg")]
+    [TestCase("Pf_TestData_3.json", "Pf_GoldenImage_3.jpg")]
+    public async Task GeneratePureFictionGoldenImage(string testDataFileName, string goldenImageFileName)
+    {
+        var testData = await JsonSerializer.DeserializeAsync<HsrEndInformation>(
+               File.OpenRead(Path.Combine(AppContext.BaseDirectory, "TestData", "Hsr", testDataFileName)));
+        Assert.That(testData, Is.Not.Null);
 
-    // [Test]
-    // [TestCase("As_TestData_1.json", "As_GoldenImage_1.jpg")]
-    // [TestCase("As_TestData_2.json", "As_GoldenImage_2.jpg")]
-    // [TestCase("As_TestData_3.json", "As_GoldenImage_3.jpg")]
-    // public async Task GenerateBossChallengeGoldenImage(string testDataFileName, string goldenImageFileName)
-    // {
-    //     HsrEndInformation? testData = await JsonSerializer.DeserializeAsync<HsrEndInformation>(
-    //         File.OpenRead(Path.Combine(AppContext.BaseDirectory, "TestData", "Hsr", testDataFileName)), JsonOptions);
-    //     Assert.That(testData, Is.Not.Null);
-    //
-    //     GameProfileDto userGameData = GetTestUserGameData();
-    //
-    //     Stream image = await m_Service.GetCardAsync(
-    //         new HsrEndGameGenerationContext(TestUserId, testData!, Server.Asia, userGameData, HsrEndGameMode.ApocalypticShadow));
-    //
-    //     await using FileStream fileStream = File.Create(Path.Combine(AppContext.BaseDirectory, "Assets", "Hsr",
-    //         "TestAssets", goldenImageFileName));
-    // await image.CopyToAsync(fileStream);
-    //
-    //     Assert.That(image, Is.Not.Null);
-    // }
+        var userGameData = GetTestUserGameData();
+
+        var cardContext = new BaseCardGenerationContext<HsrEndInformation>(TestUserId, testData!, userGameData);
+        cardContext.SetParameter("server", Server.Asia);
+        cardContext.SetParameter("mode", HsrEndGameMode.PureFiction);
+
+        var image = await m_Service.GetCardAsync(cardContext);
+
+        await using var fileStream = File.Create(Path.Combine(AppContext.BaseDirectory, "Assets", "Hsr",
+            "TestAssets", goldenImageFileName));
+        await image.CopyToAsync(fileStream);
+        await fileStream.FlushAsync();
+
+        Assert.That(image, Is.Not.Null);
+    }
+
+    [Explicit]
+    [Test]
+    [TestCase("As_TestData_1.json", "As_GoldenImage_1.jpg")]
+    [TestCase("As_TestData_2.json", "As_GoldenImage_2.jpg")]
+    [TestCase("As_TestData_3.json", "As_GoldenImage_3.jpg")]
+    public async Task GenerateBossChallengeGoldenImage(string testDataFileName, string goldenImageFileName)
+    {
+        var testData = await JsonSerializer.DeserializeAsync<HsrEndInformation>(
+            File.OpenRead(Path.Combine(AppContext.BaseDirectory, "TestData", "Hsr", testDataFileName)), JsonOptions);
+        Assert.That(testData, Is.Not.Null);
+
+        var userGameData = GetTestUserGameData();
+
+        var cardContext = new BaseCardGenerationContext<HsrEndInformation>(TestUserId, testData!, userGameData);
+        cardContext.SetParameter("server", Server.Asia);
+        cardContext.SetParameter("mode", HsrEndGameMode.ApocalypticShadow);
+
+        var image = await m_Service.GetCardAsync(cardContext);
+
+        await using var fileStream = File.Create(Path.Combine(AppContext.BaseDirectory, "Assets", "Hsr",
+            "TestAssets", goldenImageFileName));
+        await image.CopyToAsync(fileStream);
+        await fileStream.FlushAsync();
+
+        Assert.That(image, Is.Not.Null);
+    }
 }

--- a/MehrakBot/Services/Application/Mehrak.Application/Extensions/ImageIconExtensions.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Extensions/ImageIconExtensions.cs
@@ -1,0 +1,36 @@
+﻿using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Drawing;
+using SixLabors.ImageSharp.Drawing.Processing;
+using SixLabors.ImageSharp.Processing;
+
+namespace Mehrak.Application.Extensions;
+
+public static class ImageIconExtensions
+{
+    public static IImageProcessingContext DrawCenteredIcon(this IImageProcessingContext ctx, Image icon, PointF center, float radius,
+        float padding = 0, Color? background = null, Color? outline = null)
+    {
+        var ellipse = new EllipsePolygon(center, radius);
+
+        if (background.HasValue)
+        {
+            ctx.Fill(background.Value, ellipse);
+        }
+        if (outline.HasValue)
+        {
+            ctx.Draw(outline.Value, 2, ellipse);
+        }
+
+        var iconSize = (radius * 2 - padding) / Math.Sqrt(2);
+        using var resizedIcon = icon.Clone(x => x.Resize(new ResizeOptions
+        {
+            Mode = ResizeMode.Max,
+            Size = new Size((int)iconSize, (int)iconSize)
+        }));
+
+        var iconPosition = new Point((int)(center.X - resizedIcon.Width / 2), (int)(center.Y - resizedIcon.Height / 2));
+
+        ctx.DrawImage(resizedIcon, iconPosition, 1f);
+        return ctx;
+    }
+}

--- a/MehrakBot/Services/Application/Mehrak.Application/Extensions/ImageIconExtensions.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Extensions/ImageIconExtensions.cs
@@ -17,12 +17,19 @@ public static class ImageIconExtensions
     public static IImageProcessingContext DrawCenteredIcon(this IImageProcessingContext ctx, Image icon, PointF center, float radius,
         float padding, Color background, Color outline, float outlineWidth)
     {
+        if (radius <= 0)
+            throw new ArgumentOutOfRangeException(nameof(radius), "Radius must be positive.");
+
+        var iconSize = radius * 2 - padding;
+
+        if (iconSize <= 0)
+            throw new ArgumentOutOfRangeException(nameof(padding), "Padding must be smaller than the icon diameter.");
+
         var ellipse = new EllipsePolygon(center, radius);
 
         ctx.Fill(background, ellipse);
         ctx.Draw(outline, outlineWidth, ellipse);
 
-        var iconSize = radius * 2 - padding;
         using var resizedIcon = icon.Clone(x => x.Resize(new ResizeOptions
         {
             Mode = ResizeMode.Max,

--- a/MehrakBot/Services/Application/Mehrak.Application/Extensions/ImageIconExtensions.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Extensions/ImageIconExtensions.cs
@@ -10,18 +10,19 @@ public static class ImageIconExtensions
     public static IImageProcessingContext DrawCenteredIcon(this IImageProcessingContext ctx, Image icon, PointF center, float radius,
         float padding = 0, Color? background = null, Color? outline = null)
     {
+        return ctx.DrawCenteredIcon(icon, center, radius, padding,
+            background ?? Color.Transparent, outline ?? Color.Transparent, 2f);
+    }
+
+    public static IImageProcessingContext DrawCenteredIcon(this IImageProcessingContext ctx, Image icon, PointF center, float radius,
+        float padding, Color background, Color outline, float outlineWidth)
+    {
         var ellipse = new EllipsePolygon(center, radius);
 
-        if (background.HasValue)
-        {
-            ctx.Fill(background.Value, ellipse);
-        }
-        if (outline.HasValue)
-        {
-            ctx.Draw(outline.Value, 2, ellipse);
-        }
+        ctx.Fill(background, ellipse);
+        ctx.Draw(outline, outlineWidth, ellipse);
 
-        var iconSize = (radius * 2 - padding) / Math.Sqrt(2);
+        var iconSize = radius * 2 - padding;
         using var resizedIcon = icon.Clone(x => x.Resize(new ResizeOptions
         {
             Mode = ResizeMode.Max,

--- a/MehrakBot/Services/Application/Mehrak.Application/Services/Genshin/Character/GenshinCharacterCardService.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Services/Genshin/Character/GenshinCharacterCardService.cs
@@ -3,6 +3,7 @@
 using System.Numerics;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using Mehrak.Application.Extensions;
 using Mehrak.Application.Services.Abstractions;
 using Mehrak.Application.Utility;
 using Mehrak.Domain.Common;
@@ -280,10 +281,8 @@ internal class GenshinCharacterCardService : ICardService<GenshinCharacterInform
                 {
                     var skill = skillIcons[i];
                     var offset = i * 150;
-                    EllipsePolygon skillEllipse = new(120, 900 - offset, 60);
-                    ctx.Fill(Color.DarkSlateGray, skillEllipse);
-                    ctx.DrawImage(skill.Image, new Point(70, 850 - offset), 1f);
-                    ctx.Draw(backgroundColor, 5f, skillEllipse.AsClosedPath());
+                    ctx.DrawCenteredIcon(skill.Image, new PointF(120, 900 - offset), 60, 20, Color.DarkSlateGray,
+                        backgroundColor, 5f);
                     EllipsePolygon talentEllipse = new(120, 960 - offset, 25);
                     ctx.Fill(skill.Data.IsConstAffected ? Color.DodgerBlue : Color.DarkGray, talentEllipse);
                     ctx.DrawText(new RichTextOptions(m_MediumFont)
@@ -307,10 +306,8 @@ internal class GenshinCharacterCardService : ICardService<GenshinCharacterInform
                     if (!constellation.Active)
                         constellation.Image.Mutate(x => x.Brightness(0.5f));
                     var offset = i * 140;
-                    EllipsePolygon constEllipse = new(1050, 1000 - offset, 50);
-                    ctx.Fill(Color.DarkSlateGray, constEllipse);
-                    ctx.DrawImage(constellation.Image, new Point(1005, 955 - offset), 1f);
-                    ctx.Draw(backgroundColor, 5f, constEllipse.AsClosedPath());
+                    ctx.DrawCenteredIcon(constellation.Image, new PointF(1050, 1000 - offset), 50, 10,
+                        Color.DarkSlateGray, backgroundColor, 5f);
                 }
 
                 ctx.DrawImage(weaponImage, new Point(1200, 40), 1f);

--- a/MehrakBot/Services/Application/Mehrak.Application/Services/Hsr/Anomaly/HsrAnomalyApplicationService.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Services/Hsr/Anomaly/HsrAnomalyApplicationService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json;
 using Mehrak.Application.Builders;
+using Mehrak.Application.Extensions;
 using Mehrak.Application.Services.Abstractions;
 using Mehrak.Application.Services.Common;
 using Mehrak.Application.Services.Common.Types;
@@ -124,7 +125,7 @@ internal class HsrAnomalyApplicationService : BaseAttachmentApplicationService
             if (bestRecord.BossRecord != null)
             {
                 tasks.Add(m_ImageUpdaterService.UpdateImageAsync(bestRecord.BossRecord.Buff.ToImageData(),
-                    new ImageProcessorBuilder().Build()));
+                    new ImageProcessorBuilder().AddOperation(x => x.CropTransparentPixels()).Build()));
             }
 
             var completed = await Task.WhenAll(tasks);

--- a/MehrakBot/Services/Application/Mehrak.Application/Services/Hsr/Anomaly/HsrAnomalyCardService.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Services/Hsr/Anomaly/HsrAnomalyCardService.cs
@@ -1,17 +1,16 @@
-﻿using Mehrak.Application.Services.Abstractions;
-using System.Numerics;
+﻿using System.Numerics;
 using System.Text.Json;
+using Mehrak.Application.Extensions;
 using Mehrak.Application.Models;
+using Mehrak.Application.Services.Abstractions;
 using Mehrak.Application.Utility;
 using Mehrak.Domain.Common;
 using Mehrak.Domain.Models.Abstractions;
 using Mehrak.Domain.Repositories;
 using Mehrak.Domain.Services.Abstractions;
 using Mehrak.GameApi.Hsr.Types;
-using Microsoft.Extensions.Logging;
 using SixLabors.Fonts;
 using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Drawing;
 using SixLabors.ImageSharp.Drawing.Processing;
 using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.PixelFormats;
@@ -124,8 +123,6 @@ internal class HsrAnomalyCardService : ICardService<HsrAnomalyInformation>, IAsy
                 : null;
             using var medalImage = await Image.LoadAsync(await m_ImageRepository.DownloadFileToStreamAsync(anomalyData.ToMedalName()));
 
-            buffImage?.Mutate(ctx => ctx.Resize(110, 0));
-
             var lookup = avatarImages.GetAlternateLookup<int>();
 
             using var background = m_Background.CloneAs<Rgba32>();
@@ -237,10 +234,7 @@ internal class HsrAnomalyCardService : ICardService<HsrAnomalyInformation>, IAsy
                 }, record.RoundNum.ToString(), Color.White);
                 ctx.DrawImage(m_CycleIcon, new Point(900, 20), 1f);
 
-                IPath ellipse = new EllipsePolygon(new PointF(1055, 170), 55);
-                ctx.Fill(Color.Black, ellipse);
-                ctx.Draw(Color.White, 1f, ellipse);
-                ctx.DrawImage(buffImage!, new Point(1000, 120), 1f);
+                ctx.DrawCenteredIcon(buffImage!, new PointF(1055, 170), 55, 0, Color.Black, Color.White);
             }
             else
             {

--- a/MehrakBot/Services/Application/Mehrak.Application/Services/Hsr/Character/HsrCharacterCardService.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Services/Hsr/Character/HsrCharacterCardService.cs
@@ -2,6 +2,7 @@
 
 using System.Numerics;
 using System.Text.Json;
+using Mehrak.Application.Extensions;
 using Mehrak.Application.Services.Abstractions;
 using Mehrak.Application.Utility;
 using Mehrak.Domain.Common;
@@ -327,11 +328,9 @@ public class HsrCharacterCardService : ICardService<HsrCharacterInformation>, IA
                 for (var i = 0; i < ranks.Length; i++)
                 {
                     var offset = i * 100;
-                    EllipsePolygon ellipse = new(new PointF(900, 1115 - offset), 45);
-                    ctx.Fill(new SolidBrush(Color.DarkSlateGray), ellipse);
                     if (!ranks[i].Active) ranks[i].Image.Mutate(x => x.Brightness(0.5f));
-                    ctx.DrawImage(ranks[i].Image, new Point(860, 1075 - offset), 1f);
-                    ctx.Draw(accentColor, 5, ellipse.AsClosedPath());
+                    ctx.DrawCenteredIcon(ranks[i].Image, new PointF(900, 1115 - offset), 45, 10, Color.DarkSlateGray,
+                        accentColor, 5f);
                 }
 
                 for (var i = 0; i < baseSkillImages.Length; i++)
@@ -342,10 +341,8 @@ public class HsrCharacterCardService : ICardService<HsrCharacterInformation>, IA
                         "Elation Skill" => Color.FromRgb(255, 176, 161),
                         _ => accentColor
                     };
-                    EllipsePolygon ellipse = new(new PointF(900, 80 + offset), 45);
-                    ctx.Fill(new SolidBrush(Color.DarkSlateGray), ellipse);
-                    ctx.DrawImage(baseSkillImages[i].Image, new Point(860, 40 + offset), 1f);
-                    ctx.Draw(skillColor, 5, ellipse.AsClosedPath());
+                    ctx.DrawCenteredIcon(baseSkillImages[i].Image, new PointF(900, 80 + offset), 45, 10,
+                        Color.DarkSlateGray, skillColor, 5f);
 
                     EllipsePolygon levelEllipse = new(new PointF(865, 115 + offset), 20);
                     ctx.Fill(new SolidBrush(Color.LightSlateGray), levelEllipse);
@@ -370,18 +367,14 @@ public class HsrCharacterCardService : ICardService<HsrCharacterInformation>, IA
                         if (skill.Data.PointType == 3)
                         {
                             var xOffset = j * 100;
-                            EllipsePolygon ellipse = new(new PointF(1020 + xOffset, 80 + yOffset), 45);
-                            ctx.Fill(new SolidBrush(Color.DarkSlateGray), ellipse);
-                            ctx.DrawImage(skill.Image, new Point(980 + xOffset, 40 + yOffset), 1f);
-                            ctx.Draw(accentColor, 5, ellipse.AsClosedPath());
+                            ctx.DrawCenteredIcon(skill.Image, new PointF(1020 + xOffset, 80 + yOffset), 45, 10,
+                                Color.DarkSlateGray, accentColor, 5f);
                         }
                         else
                         {
                             var xOffset = (j - 1) * 100;
-                            EllipsePolygon ellipse = new(new PointF(1120 + xOffset, 80 + yOffset), 30);
-                            ctx.Fill(new SolidBrush(Color.DarkSlateGray), ellipse);
-                            ctx.DrawImage(skill.Image, new Point(1095 + xOffset, 55 + yOffset), 1f);
-                            ctx.Draw(accentColor, 5, ellipse.AsClosedPath());
+                            ctx.DrawCenteredIcon(skill.Image, new PointF(1120 + xOffset, 80 + yOffset), 30, 10,
+                                Color.DarkSlateGray, accentColor, 5f);
                         }
                     }
                 }
@@ -391,10 +384,8 @@ public class HsrCharacterCardService : ICardService<HsrCharacterInformation>, IA
                 for (var i = 0; i < servantImages.Length; i++)
                 {
                     var offset = (i + type4Skill) * 120;
-                    EllipsePolygon ellipse = new(new PointF(900 + offset, 480), 45);
-                    ctx.Fill(new SolidBrush(Color.DarkSlateGray), ellipse);
-                    ctx.DrawImage(servantImages[i].Image, new Point(860 + offset, 440), 1f);
-                    ctx.Draw(accentColor, 5, ellipse.AsClosedPath());
+                    ctx.DrawCenteredIcon(servantImages[i].Image, new PointF(900 + offset, 480), 45, 10,
+                        Color.DarkSlateGray, accentColor, 5f);
 
                     EllipsePolygon levelEllipse = new(new PointF(865 + offset, 515), 20);
                     ctx.Fill(new SolidBrush(Color.LightSlateGray), levelEllipse);

--- a/MehrakBot/Services/Application/Mehrak.Application/Services/Hsr/EndGame/HsrEndGameApplicationService.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Services/Hsr/EndGame/HsrEndGameApplicationService.cs
@@ -2,6 +2,7 @@
 
 using System.Text.Json;
 using Mehrak.Application.Builders;
+using Mehrak.Application.Extensions;
 using Mehrak.Application.Services.Abstractions;
 using Mehrak.Application.Services.Common;
 using Mehrak.Application.Services.Common.Types;
@@ -117,7 +118,8 @@ public class HsrEndGameApplicationService : BaseAttachmentApplicationService
                 .SelectMany(x => new List<HsrEndBuff> { x.Node1!.Buff, x.Node2!.Buff })
                 .DistinctBy(x => x.Id)
                 .Select(x =>
-                    m_ImageUpdaterService.UpdateImageAsync(x.ToImageData(), new ImageProcessorBuilder().Build()));
+                    m_ImageUpdaterService.UpdateImageAsync(x.ToImageData(),
+                        new ImageProcessorBuilder().AddOperation(x => x.CropTransparentPixels()).Build()));
 
             var completed = await Task.WhenAll(tasks.Concat(buffTasks));
 

--- a/MehrakBot/Services/Application/Mehrak.Application/Services/Hsr/EndGame/HsrEndGameCardService.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Services/Hsr/EndGame/HsrEndGameCardService.cs
@@ -1,9 +1,10 @@
 ﻿#region
 
-using Mehrak.Application.Services.Abstractions;
 using System.Numerics;
 using System.Text.Json;
+using Mehrak.Application.Extensions;
 using Mehrak.Application.Models;
+using Mehrak.Application.Services.Abstractions;
 using Mehrak.Application.Utility;
 using Mehrak.Domain.Common;
 using Mehrak.Domain.Enums;
@@ -108,15 +109,11 @@ internal class HsrEndGameCardService : ICardService<HsrEndInformation>, IAsyncIn
                 .Where(x => x is { Node1: not null, Node2: not null })
                 .SelectMany(x => new HsrEndBuff[] { x.Node1!.Buff, x.Node2!.Buff })
                 .Where(x => x is not null)
-                .DistinctBy(x => x.Id).ToAsyncEnumerable().ToDictionaryAsync(
+                .DistinctBy(x => x.Id)
+                .ToAsyncEnumerable()
+                .ToDictionaryAsync(
                     async (x, token) => await Task.FromResult(x.Id),
-                    async (x, token) =>
-                    {
-                        var image =
-                            await Image.LoadAsync(await m_ImageRepository.DownloadFileToStreamAsync(x.ToImageName()), token);
-                        image.Mutate(ctx => ctx.Resize(110, 0));
-                        return image;
-                    });
+                    async (x, token) => await Image.LoadAsync(await m_ImageRepository.DownloadFileToStreamAsync(x.ToImageName(), token), token));
 
             disposables.AddRange(avatarImages.Keys);
             disposables.AddRange(avatarImages.Values);
@@ -299,11 +296,7 @@ internal class HsrEndGameCardService : ICardService<HsrEndInformation>, IAsyncIn
                             1f);
 
                     ctx.DrawImage(node1, new Point(xOffset + 55, yOffset + 130), 1f);
-                    IPath ellipse = new EllipsePolygon(new PointF(xOffset + 780, yOffset + 220), 55);
-                    ctx.Fill(Color.Black, ellipse);
-                    ctx.Draw(Color.White, 1f, ellipse);
-                    ctx.DrawImage(buffImages[floorData.Node1.Buff.Id], new Point(xOffset + 725, yOffset + 170),
-                        1f);
+                    ctx.DrawCenteredIcon(buffImages[floorData.Node1.Buff.Id], new Point(xOffset + 780, yOffset + 220), 55, 0, Color.Black, Color.White);
                     ctx.DrawLine(Color.White, 2f, new PointF(xOffset + 40, yOffset + 335),
                         new PointF(xOffset + 860, yOffset + 335));
                     ctx.DrawText("Node 2", m_NormalFont, Color.White, new PointF(xOffset + 45, yOffset + 350));
@@ -317,12 +310,7 @@ internal class HsrEndGameCardService : ICardService<HsrEndInformation>, IAsyncIn
                             1f);
 
                     ctx.DrawImage(node2, new Point(xOffset + 55, yOffset + 395), 1f);
-                    ellipse = ellipse.Translate(0, 265);
-                    ctx.Fill(Color.Black, ellipse);
-                    ctx.Draw(Color.White, 1f, ellipse);
-                    ctx.DrawImage(buffImages[floorData.Node2.Buff.Id], new Point(xOffset + 725, yOffset + 425),
-                        1f);
-
+                    ctx.DrawCenteredIcon(buffImages[floorData.Node2.Buff.Id], new Point(xOffset + 780, yOffset + 485), 55, 0, Color.Black, Color.White);
                     for (var i = 0; i < 3; i++)
                         ctx.DrawImage(i < floorData.StarNum ? m_StarLit : m_StarUnlit,
                             new Point(xOffset + 730 + i * 50, yOffset + 5), 1f);


### PR DESCRIPTION
- Add extension class and method to draw centered icon
- Replaced Genshin Character, HSR Character, HSR End Game, HSR Anomaly card generation with centered icon extension methods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled test coverage for end-game card generation scenarios.

* **Improvements**
  * Refined icon rendering in character and anomaly cards for improved visual consistency.
  * Enhanced image processing with transparent pixel cropping for cleaner output.

* **Tests**
  * Added test cases for end-game card image generation.
  * Updated golden image generation test utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->