### PR TITLE
HSR Relic to use new file name format

### DIFF
--- a/MehrakBot/Common/Mehrak.Domain/Common/FileNameFormat.cs
+++ b/MehrakBot/Common/Mehrak.Domain/Common/FileNameFormat.cs
@@ -67,6 +67,11 @@ public static class FileNameFormat
         public const string SideAvatarName = "hsr_side_avatar_{0}";
 
         /// <summary>
+        /// HSR relic file name format, where {0} is the relic ID
+        /// </summary>
+        public const string RelicName = "hsr_relic_{0}";
+
+        /// <summary>
         /// HSR stats file name format, where {0} is the stat ID
         /// </summary>
         public const string StatsName = "hsr_stats_{0}";

--- a/MehrakBot/Common/Mehrak.GameApi/Hsr/Types/HsrCharacterInformation.cs
+++ b/MehrakBot/Common/Mehrak.GameApi/Hsr/Types/HsrCharacterInformation.cs
@@ -142,7 +142,12 @@ public class Relic
 
     public string ToImageName()
     {
-        return string.Format(FileNameFormat.Hsr.FileName, Id.ToString()[1..]);
+        return string.Format(FileNameFormat.Hsr.RelicName, Id.ToString()[1..]);
+    }
+
+    public string ToImageName(int slot)
+    {
+        return string.Format(FileNameFormat.Hsr.RelicName, $"{GetSetId()}{slot}");
     }
 
     public int GetSetId()

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Hsr/Character/HsrCharacterApplicationServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Hsr/Character/HsrCharacterApplicationServiceTests.cs
@@ -777,8 +777,11 @@ public class HsrCharacterApplicationServiceTests
         var context1 = CreateContext(3, 3ul, "test", ("character", "Trailblazer"), ("server", Server.Asia.ToString()));
 
         var firstResult = await service1.ExecuteAsync(context1);
-        Assert.That(firstResult.IsSuccess, Is.True, firstResult.ErrorMessage);
-        Assert.That(existingFiles.Count(f => f.StartsWith("hsr_118")), Is.EqualTo(2));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(firstResult.IsSuccess, Is.True, firstResult.ErrorMessage);
+            Assert.That(existingFiles.Count(f => f.StartsWith("hsr_relic_118")), Is.EqualTo(2));
+        }
 
         var (service2, characterApiMock2, _, _, wikiApiMock2, imageRepositoryMock2, imageUpdaterMock2, cardServiceMock2,
             gameRoleApiMock2, _, _, attachmentStorageMock2, _) = SetupMocks();
@@ -822,7 +825,7 @@ public class HsrCharacterApplicationServiceTests
         var secondResult = await service2.ExecuteAsync(context2);
         Assert.That(secondResult.IsSuccess, Is.True, secondResult.ErrorMessage);
 
-        Assert.That(existingFiles.Count(f => f.StartsWith("hsr_118")), Is.EqualTo(4));
+        Assert.That(existingFiles.Count(f => f.StartsWith("hsr_relic_118")), Is.EqualTo(4));
         attachmentStorageMock1.Verify(x => x.StoreAsync(It.IsAny<string>(), It.IsAny<Stream>(), It.IsAny<CancellationToken>()), Times.Once);
         attachmentStorageMock2.Verify(x => x.StoreAsync(It.IsAny<string>(), It.IsAny<Stream>(), It.IsAny<CancellationToken>()), Times.Once);
     }

--- a/MehrakBot/Services/Application/Mehrak.Application/Services/Hsr/Character/HsrCharacterApplicationService.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Services/Hsr/Character/HsrCharacterApplicationService.cs
@@ -207,12 +207,10 @@ public class HsrCharacterApplicationService : BaseAttachmentApplicationService
                     end = 6;
                 }
 
-                var setId = x.GetSetId();
-
                 for (var i = start; i <= end; i++)
                 {
                     if (relicWiki.ContainsKey(x.Id.ToString()) &&
-                        !await m_ImageRepository.FileExistsAsync(string.Format(FileNameFormat.Hsr.FileName, $"{setId}{i}"), token))
+                        !await m_ImageRepository.FileExistsAsync(x.ToImageName(i), token))
                         return true;
                 }
 
@@ -271,7 +269,7 @@ public class HsrCharacterApplicationService : BaseAttachmentApplicationService
         tasks.AddRange(uniqueRelicSet.Where(x => x.Value != null)
             .SelectMany(x => x.Value!.Select((e, i) =>
                 new ImageData(
-                    string.Format(FileNameFormat.Hsr.FileName, $"{x.Key.GetSetId()}{(x.Key.Pos < 5 ? i + 1 : i + 5)}"),
+                    x.Key.ToImageName(x.Key.Pos < 5 ? i + 1 : i + 5),
                     e?["icon_url"]?.GetValue<string>() ?? string.Empty))
             .Select(x => m_ImageUpdaterService.UpdateImageAsync(x, relicProcessor))));
         tasks.AddRange(characterInfo.Relics.Concat(characterInfo.Ornaments)


### PR DESCRIPTION
- Fix duplication of ID for character and relic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relic image file naming consistency to ensure proper display of relic information.

* **Chores**
  * Standardized relic image name formatting across the application.
  * Enhanced flexibility in relic image name generation for different contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->