### PR TITLE
Add proxy access for Seaweed Filer

### DIFF
--- a/Dashboard/src/components/Sidebar.vue
+++ b/Dashboard/src/components/Sidebar.vue
@@ -62,6 +62,15 @@ const handleLogout = async () => {
       </router-link>
 
       <router-link
+        v-if="userInfo.isSuperAdmin"
+        to="/dashboard/seaweed-filer"
+        class="nav-item"
+        :class="{ active: isActive('/dashboard/seaweed-filer') }"
+      >
+        Seaweed Filer
+      </router-link>
+
+      <router-link
         to="/dashboard/genshin"
         class="nav-item"
         :class="{ active: isActive('/dashboard/genshin') }"
@@ -140,7 +149,9 @@ const handleLogout = async () => {
   border-radius: 8px;
   color: #ccc;
   text-decoration: none;
-  transition: background-color 0.2s, color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
 }
 
 .nav-item:hover {

--- a/Dashboard/src/router/index.js
+++ b/Dashboard/src/router/index.js
@@ -10,6 +10,7 @@ import GenshinView from "../views/GenshinView.vue";
 import HsrView from "../views/HsrView.vue";
 import ZzzView from "../views/ZzzView.vue";
 import Hi3View from "../views/Hi3View.vue";
+import SeaweedFilerView from "../views/SeaweedFilerView.vue";
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -62,6 +63,11 @@ const router = createRouter({
           path: "hi3",
           name: "hi3",
           component: Hi3View,
+        },
+        {
+          path: "seaweed-filer",
+          name: "seaweed-filer",
+          component: SeaweedFilerView,
         },
         {
           path: "change-password",

--- a/Dashboard/src/views/SeaweedFilerView.vue
+++ b/Dashboard/src/views/SeaweedFilerView.vue
@@ -1,0 +1,94 @@
+<script setup>
+import { computed } from "vue";
+
+const props = defineProps({
+  userInfo: {
+    type: Object,
+    required: true,
+  },
+});
+
+const backendUrl = import.meta.env.VITE_APP_BACKEND_URL;
+
+const filerUrl = computed(() => {
+  if (!backendUrl) return "";
+  return `${backendUrl}/admin/seaweed-filer/`;
+});
+
+const openFiler = () => {
+  if (!filerUrl.value) return;
+  window.open(filerUrl.value, "_blank", "noopener,noreferrer");
+};
+</script>
+
+<template>
+  <div class="seaweed-page">
+    <header class="seaweed-header">
+      <h1>Seaweed Filer</h1>
+      <p class="seaweed-subtitle">
+        Open the filer UI in a new tab through the authenticated dashboard
+        proxy.
+      </p>
+    </header>
+
+    <div v-if="!userInfo.isSuperAdmin" class="seaweed-warning">
+      This page is only available to superadmin users.
+    </div>
+
+    <div v-else class="seaweed-card">
+      <p>
+        You are signed in as <strong>{{ userInfo.username }}</strong> with
+        superadmin access.
+      </p>
+      <button class="btn primary" @click="openFiler" :disabled="!filerUrl">
+        Open Seaweed Filer UI
+      </button>
+      <p v-if="!filerUrl" class="seaweed-error">
+        Backend URL is not configured. Set <code>VITE_APP_BACKEND_URL</code>.
+      </p>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.seaweed-page {
+  max-width: 900px;
+  margin: 0 auto;
+  text-align: left;
+}
+
+.seaweed-header {
+  margin-bottom: 1.5rem;
+}
+
+.seaweed-header h1 {
+  margin: 0;
+}
+
+.seaweed-subtitle {
+  color: #b7b7b7;
+  margin-top: 0.5rem;
+}
+
+.seaweed-card {
+  background: #2b2b2b;
+  border: 1px solid #3d3d3d;
+  border-radius: 12px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.seaweed-warning {
+  border: 1px solid #8f7a00;
+  background: rgba(143, 122, 0, 0.15);
+  color: #ffd65a;
+  border-radius: 10px;
+  padding: 1rem;
+}
+
+.seaweed-error {
+  color: #ff7d7d;
+}
+</style>

--- a/MehrakBot/Services/Dashboard/Mehrak.Dashboard/Controllers/SeaweedFilerProxyController.cs
+++ b/MehrakBot/Services/Dashboard/Mehrak.Dashboard/Controllers/SeaweedFilerProxyController.cs
@@ -39,7 +39,8 @@ public sealed class SeaweedFilerProxyController : ControllerBase
         "Transfer-Encoding",
         "Upgrade",
         "Authorization",
-        "Content-Length"
+        "Content-Length",
+        "Cookie"
     };
 
     private static readonly HashSet<string> SkippedResponseHeaders = new(StringComparer.OrdinalIgnoreCase)
@@ -51,7 +52,8 @@ public sealed class SeaweedFilerProxyController : ControllerBase
         "TE",
         "Trailer",
         "Transfer-Encoding",
-        "Upgrade"
+        "Upgrade",
+        "Set-Cookie"
     };
 
     private const string ProxyBasePath = "/admin/seaweed-filer";

--- a/MehrakBot/Services/Dashboard/Mehrak.Dashboard/Controllers/SeaweedFilerProxyController.cs
+++ b/MehrakBot/Services/Dashboard/Mehrak.Dashboard/Controllers/SeaweedFilerProxyController.cs
@@ -40,7 +40,9 @@ public sealed class SeaweedFilerProxyController : ControllerBase
         "Upgrade",
         "Authorization",
         "Content-Length",
-        "Cookie"
+        "Cookie",
+        "X-Forwarded-Host",
+        "X-Forwarded-Proto",
     };
 
     private static readonly HashSet<string> SkippedResponseHeaders = new(StringComparer.OrdinalIgnoreCase)

--- a/MehrakBot/Services/Dashboard/Mehrak.Dashboard/Controllers/SeaweedFilerProxyController.cs
+++ b/MehrakBot/Services/Dashboard/Mehrak.Dashboard/Controllers/SeaweedFilerProxyController.cs
@@ -118,7 +118,8 @@ public sealed class SeaweedFilerProxyController : ControllerBase
         catch (HttpRequestException ex)
         {
             var sanitised = Request.Path.Value?.ReplaceLineEndings(" ") ?? string.Empty;
-            m_Logger.LogError(ex, "Seaweed filer proxy request failed for {Method} {Path}", Request.Method, sanitised);
+            var sanitisedMethod = Request.Method.ReplaceLineEndings(" ").ToUpperInvariant();
+            m_Logger.LogError(ex, "Seaweed filer proxy request failed for {Method} {Path}", sanitisedMethod, sanitised);
             return StatusCode(StatusCodes.Status502BadGateway, new { error = "Unable to reach Seaweed filer." });
         }
 

--- a/MehrakBot/Services/Dashboard/Mehrak.Dashboard/Controllers/SeaweedFilerProxyController.cs
+++ b/MehrakBot/Services/Dashboard/Mehrak.Dashboard/Controllers/SeaweedFilerProxyController.cs
@@ -113,7 +113,8 @@ public sealed class SeaweedFilerProxyController : ControllerBase
         }
         catch (HttpRequestException ex)
         {
-            m_Logger.LogError(ex, "Seaweed filer proxy request failed for {Method} {Path}", Request.Method, Request.Path.Value ?? string.Empty);
+            var sanitised = Request.Path.Value?.ReplaceLineEndings(" ") ?? string.Empty;
+            m_Logger.LogError(ex, "Seaweed filer proxy request failed for {Method} {Path}", Request.Method, sanitised);
             return StatusCode(StatusCodes.Status502BadGateway, new { error = "Unable to reach Seaweed filer." });
         }
 

--- a/MehrakBot/Services/Dashboard/Mehrak.Dashboard/Controllers/SeaweedFilerProxyController.cs
+++ b/MehrakBot/Services/Dashboard/Mehrak.Dashboard/Controllers/SeaweedFilerProxyController.cs
@@ -1,0 +1,233 @@
+﻿using Mehrak.Dashboard.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace Mehrak.Dashboard.Controllers;
+
+[ApiController]
+[Authorize(Policy = "RequireSuperAdmin")]
+[Route("admin/seaweed-filer")]
+public sealed class SeaweedFilerProxyController : ControllerBase
+{
+    private static readonly HashSet<string> ReservedApiPrefixes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "admin",
+        "alias",
+        "attachments",
+        "auth",
+        "characters",
+        "codes",
+        "genshin",
+        "healthz",
+        "hi3",
+        "hsr",
+        "profile-auth",
+        "users",
+        "zzz"
+    };
+
+    private static readonly HashSet<string> SkippedRequestHeaders = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Host",
+        "Connection",
+        "Keep-Alive",
+        "Proxy-Authenticate",
+        "Proxy-Authorization",
+        "TE",
+        "Trailer",
+        "Transfer-Encoding",
+        "Upgrade",
+        "Authorization",
+        "Content-Length"
+    };
+
+    private static readonly HashSet<string> SkippedResponseHeaders = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Connection",
+        "Keep-Alive",
+        "Proxy-Authenticate",
+        "Proxy-Authorization",
+        "TE",
+        "Trailer",
+        "Transfer-Encoding",
+        "Upgrade"
+    };
+
+    private const string ProxyBasePath = "/admin/seaweed-filer";
+    private readonly IHttpClientFactory m_HttpClientFactory;
+    private readonly SeaweedFilerOptions m_Options;
+    private readonly ILogger<SeaweedFilerProxyController> m_Logger;
+
+    public SeaweedFilerProxyController(
+        IHttpClientFactory httpClientFactory,
+        IOptions<SeaweedFilerOptions> options,
+        ILogger<SeaweedFilerProxyController> logger)
+    {
+        m_HttpClientFactory = httpClientFactory;
+        m_Options = options.Value;
+        m_Logger = logger;
+    }
+
+    [AcceptVerbs("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS")]
+    [Route("")]
+    [Route("{**path}")]
+    public Task<IActionResult> Proxy(string? path, CancellationToken cancellationToken)
+    {
+        return ProxyCurrentRequest(cancellationToken);
+    }
+
+    [AcceptVerbs("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS")]
+    [Route("~/{**path}")]
+    public Task<IActionResult> ProxyFallback(string? path, CancellationToken cancellationToken)
+    {
+        if (IsReservedApiPath(Request.Path))
+            return Task.FromResult<IActionResult>(NotFound());
+
+        return ProxyCurrentRequest(cancellationToken);
+    }
+
+    private async Task<IActionResult> ProxyCurrentRequest(CancellationToken cancellationToken)
+    {
+        if (!TryCreateBaseUri(out var baseUri))
+            return Problem(statusCode: StatusCodes.Status500InternalServerError, title: "Seaweed filer proxy is not configured.");
+
+        var targetUri = BuildTargetUri(baseUri, Request.Path, Request.QueryString);
+        if (targetUri is null)
+            return BadRequest(new { error = "Invalid filer path." });
+
+        using var proxyRequest = CreateProxyRequest(targetUri);
+        AddForwardingHeaders(proxyRequest);
+
+        var client = m_HttpClientFactory.CreateClient("SeaweedFilerProxy");
+
+        try
+        {
+            using var proxyResponse = await client.SendAsync(proxyRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+
+            Response.StatusCode = (int)proxyResponse.StatusCode;
+
+            CopyResponseHeaders(proxyResponse);
+
+            await proxyResponse.Content.CopyToAsync(Response.Body, cancellationToken);
+        }
+        catch (HttpRequestException ex)
+        {
+            m_Logger.LogError(ex, "Seaweed filer proxy request failed for {Method} {Path}", Request.Method, Request.Path.Value ?? string.Empty);
+            return StatusCode(StatusCodes.Status502BadGateway, new { error = "Unable to reach Seaweed filer." });
+        }
+
+        return new EmptyResult();
+    }
+
+    private HttpRequestMessage CreateProxyRequest(Uri targetUri)
+    {
+        var requestMessage = new HttpRequestMessage(new HttpMethod(Request.Method), targetUri);
+
+        if (Request.ContentLength is > 0 || Request.Headers.ContainsKey("Transfer-Encoding"))
+            requestMessage.Content = new StreamContent(Request.Body);
+
+        foreach (var header in Request.Headers)
+        {
+            if (SkippedRequestHeaders.Contains(header.Key))
+                continue;
+
+            if (!requestMessage.Headers.TryAddWithoutValidation(header.Key, header.Value.AsEnumerable()))
+                requestMessage.Content?.Headers.TryAddWithoutValidation(header.Key, header.Value.AsEnumerable());
+        }
+
+        return requestMessage;
+    }
+
+    private static Uri? BuildTargetUri(Uri baseUri, PathString requestPath, QueryString queryString)
+    {
+        var pathValue = requestPath.Value ?? string.Empty;
+        var trimmed = pathValue.StartsWith(ProxyBasePath, StringComparison.OrdinalIgnoreCase)
+            ? pathValue[ProxyBasePath.Length..]
+            : pathValue;
+
+        var relativePath = trimmed.TrimStart('/');
+        var relative = relativePath;
+
+        if (queryString.HasValue)
+            relative += queryString.Value;
+
+        if (string.IsNullOrEmpty(relative))
+            return baseUri;
+
+        if (!Uri.TryCreate(baseUri, relative, out var targetUri))
+            return null;
+
+        if (!Uri.Compare(baseUri, targetUri, UriComponents.SchemeAndServer, UriFormat.SafeUnescaped, StringComparison.OrdinalIgnoreCase)
+                .Equals(0))
+            return null;
+
+        return targetUri;
+    }
+
+    private static bool IsReservedApiPath(PathString requestPath)
+    {
+        var pathValue = requestPath.Value?.Trim('/');
+        if (string.IsNullOrWhiteSpace(pathValue))
+            return false;
+
+        var separatorIndex = pathValue.IndexOf('/');
+        var firstSegment = separatorIndex >= 0 ? pathValue[..separatorIndex] : pathValue;
+
+        return ReservedApiPrefixes.Contains(firstSegment);
+    }
+
+    private bool TryCreateBaseUri(out Uri baseUri)
+    {
+        var configured = m_Options.BaseUrl?.Trim();
+
+        if (string.IsNullOrWhiteSpace(configured))
+        {
+            m_Logger.LogError("SeaweedFiler:BaseUrl is missing.");
+            baseUri = default!;
+            return false;
+        }
+
+        if (!configured.EndsWith('/'))
+            configured += "/";
+
+        if (!Uri.TryCreate(configured, UriKind.Absolute, out baseUri!))
+        {
+            m_Logger.LogError("SeaweedFiler:BaseUrl is invalid: {BaseUrl}", configured);
+            return false;
+        }
+
+        return true;
+    }
+
+    private void AddForwardingHeaders(HttpRequestMessage requestMessage)
+    {
+        var remoteAddress = HttpContext.Connection.RemoteIpAddress?.ToString();
+        if (!string.IsNullOrWhiteSpace(remoteAddress))
+            requestMessage.Headers.TryAddWithoutValidation("X-Forwarded-For", remoteAddress);
+
+        requestMessage.Headers.TryAddWithoutValidation("X-Forwarded-Proto", Request.Scheme);
+        requestMessage.Headers.TryAddWithoutValidation("X-Forwarded-Host", Request.Host.Value);
+    }
+
+    private void CopyResponseHeaders(HttpResponseMessage proxyResponse)
+    {
+        foreach (var header in proxyResponse.Headers)
+        {
+            if (SkippedResponseHeaders.Contains(header.Key))
+                continue;
+
+            Response.Headers[header.Key] = header.Value.ToArray();
+        }
+
+        foreach (var header in proxyResponse.Content.Headers)
+        {
+            if (SkippedResponseHeaders.Contains(header.Key))
+                continue;
+
+            Response.Headers[header.Key] = header.Value.ToArray();
+        }
+
+        Response.Headers.Remove("transfer-encoding");
+    }
+}

--- a/MehrakBot/Services/Dashboard/Mehrak.Dashboard/Models/SeaweedFilerOptions.cs
+++ b/MehrakBot/Services/Dashboard/Mehrak.Dashboard/Models/SeaweedFilerOptions.cs
@@ -1,0 +1,6 @@
+namespace Mehrak.Dashboard.Models;
+
+public sealed class SeaweedFilerOptions
+{
+    public string BaseUrl { get; set; } = string.Empty;
+}

--- a/MehrakBot/Services/Dashboard/Mehrak.Dashboard/Program.cs
+++ b/MehrakBot/Services/Dashboard/Mehrak.Dashboard/Program.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using System.Threading.RateLimiting;
 using Mehrak.Dashboard.Auth;
+using Mehrak.Dashboard.Models;
 using Mehrak.Dashboard.Services;
 using Mehrak.Domain.Auth;
 using Mehrak.Domain.Protobuf;
@@ -84,6 +85,7 @@ public class Program
 
         builder.Services.Configure<S3StorageConfig>(builder.Configuration.GetSection("Storage"));
         builder.Services.Configure<CharacterCacheConfig>(builder.Configuration.GetSection("CharacterCache"));
+        builder.Services.Configure<SeaweedFilerOptions>(builder.Configuration.GetSection("SeaweedFiler"));
 
         builder.Services.Configure<RedisConfig>(builder.Configuration.GetSection("Redis"));
         builder.Services.Configure<PgConfig>(builder.Configuration.GetSection("Postgres"));
@@ -102,6 +104,12 @@ public class Program
             {
                 UseCookies = false
             }).ConfigureHttpClient(client => client.Timeout = TimeSpan.FromSeconds(30));
+
+        builder.Services.AddHttpClient("SeaweedFilerProxy").ConfigurePrimaryHttpMessageHandler(() =>
+            new HttpClientHandler
+            {
+                UseCookies = false
+            }).ConfigureHttpClient(client => client.Timeout = TimeSpan.FromMinutes(10));
 
         builder.Services.AddGrpcClient<ApplicationService.ApplicationServiceClient>(options =>
         {

--- a/MehrakBot/Services/Dashboard/Mehrak.Dashboard/appsettings.json
+++ b/MehrakBot/Services/Dashboard/Mehrak.Dashboard/appsettings.json
@@ -36,6 +36,9 @@
     "Region": "us-east-1",
     "ForcePathStyle": true
   },
+  "SeaweedFiler": {
+    "BaseUrl": "http://seaweed-filer:8888"
+  },
   "AttachmentStorage": {
     "Bucket": "mehrak-attachments"
   },

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -52,12 +52,14 @@ services:
         condition: service_healthy
     networks:
       - mehrak-network
+      - seaweed-network
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
       - Dashboard__AdminUsername=${DASHBOARD_ADMIN_USERNAME}
       - Dashboard__AdminPassword=${DASHBOARD_ADMIN_PASSWORD}
       - Dashboard__AdminDiscordId=${DASHBOARD_ADMIN_DISCORD_ID}
       - Dashboard__Origin=${DASHBOARD_ORIGIN}
+      - SeaweedFiler__BaseUrl=http://seaweed-filer:8888
       - Redis__ConnectionString=redis:6379,password=${REDIS_PASSWORD}
       - Postgres__ConnectionString=Host=postgres;Port=5432;Database=mehrak_dev;Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD}
       - Storage__SecretKey=${SEAWEED_SECRET_KEY}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,12 +46,14 @@ services:
         condition: service_healthy
     networks:
       - mehrak-network
+      - seaweed-network
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
       - Dashboard__AdminUsername=${DASHBOARD_ADMIN_USERNAME}
       - Dashboard__AdminPassword=${DASHBOARD_ADMIN_PASSWORD}
       - Dashboard__AdminDiscordId=${DASHBOARD_ADMIN_DISCORD_ID}
       - Dashboard__Origin=${DASHBOARD_ORIGIN}
+      - SeaweedFiler__BaseUrl=http://seaweed-filer:8888
       - Redis__ConnectionString=redis:6379,password=${REDIS_PASSWORD}
       - Postgres__ConnectionString=Host=postgres;Port=5432;Database=mehrak_dev;Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD}
       - Storage__SecretKey=${SEAWEED_SECRET_KEY}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Seaweed Filer integration: new superadmin-only dashboard entry and view that opens the filer in a new tab and shows access warnings when unavailable.
  * Server-side proxy to securely route admin filer requests through the dashboard.

* **Chores**
  * Added configuration, options binding, named HTTP client, and compose/network env settings to enable dashboard↔filer connectivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->