### PR TITLE
Fix centered icon not centered

### DIFF
--- a/MehrakBot/Services/Application/Mehrak.Application/Services/Hsr/EndGame/HsrEndGameApplicationService.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Services/Hsr/EndGame/HsrEndGameApplicationService.cs
@@ -2,7 +2,6 @@
 
 using System.Text.Json;
 using Mehrak.Application.Builders;
-using Mehrak.Application.Extensions;
 using Mehrak.Application.Services.Abstractions;
 using Mehrak.Application.Services.Common;
 using Mehrak.Application.Services.Common.Types;
@@ -119,7 +118,7 @@ public class HsrEndGameApplicationService : BaseAttachmentApplicationService
                 .DistinctBy(x => x.Id)
                 .Select(x =>
                     m_ImageUpdaterService.UpdateImageAsync(x.ToImageData(),
-                        new ImageProcessorBuilder().AddOperation(x => x.CropTransparentPixels()).Build()));
+                        new ImageProcessorBuilder().Build()));
 
             var completed = await Task.WhenAll(tasks.Concat(buffTasks));
 


### PR DESCRIPTION
HSR End game card buff icons isn't centered. This is a temporary workaround until the ongoing image component refactoring merges into 1.2.0