### PR TITLE
Use perceptual hash for golden image tests

### DIFF
--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Extensions/ImageAssertExtensions.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Extensions/ImageAssertExtensions.cs
@@ -12,6 +12,7 @@ public static class IsImage
     public static ImageIdenticalConstraint IdenticalTo(Stream expected, double similarityThreshold = 98.0)
     {
         using var ms = new MemoryStream();
+        expected.Position = 0;
         expected.CopyTo(ms);
         return new(ms.ToArray(), similarityThreshold);
     }
@@ -21,17 +22,15 @@ public class ImageIdenticalConstraint : Constraint
 {
     private readonly byte[] m_Expected;
     private readonly double m_SimilarityThreshold;
-    private double m_ActualSimilarity;
     public ImageIdenticalConstraint(byte[] expected, double similarityThreshold)
     {
         m_Expected = expected;
         m_SimilarityThreshold = similarityThreshold;
-        m_ActualSimilarity = -1;
     }
 
     public override ConstraintResult ApplyTo<TActual>(TActual actual)
     {
-        byte[] actualBytes = actual switch
+        var actualBytes = actual switch
         {
             byte[] bytes => bytes,
             Stream stream => ReadStream(stream),
@@ -45,16 +44,17 @@ public class ImageIdenticalConstraint : Constraint
         var actualHash = hashAlgorithm.Hash(actualMs);
         var expectedHash = hashAlgorithm.Hash(expectedMs);
 
-        m_ActualSimilarity = CompareHash.Similarity(actualHash, expectedHash);
+        var actualSimilarity = CompareHash.Similarity(actualHash, expectedHash);
 
-        var isSuccess = m_ActualSimilarity >= m_SimilarityThreshold;
+        var isSuccess = actualSimilarity >= m_SimilarityThreshold;
 
-        return new ImageConstraintResult(this, actual, isSuccess, m_ActualSimilarity, m_SimilarityThreshold);
+        return new ImageConstraintResult(this, actual, isSuccess, actualSimilarity, m_SimilarityThreshold);
     }
 
     private static byte[] ReadStream(Stream stream)
     {
         using var ms = new MemoryStream();
+        stream.Position = 0;
         stream.CopyTo(ms);
         return ms.ToArray();
     }

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Extensions/ImageAssertExtensions.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Extensions/ImageAssertExtensions.cs
@@ -1,14 +1,11 @@
 using CoenM.ImageHash;
 using CoenM.ImageHash.HashAlgorithms;
 using NUnit.Framework.Constraints;
-using SixLabors.ImageSharp;
 
 namespace Mehrak.Application.Tests.Extensions;
 
 public static class IsImage
 {
-    private static readonly AverageHash HashAlgorithm = new();
-
     public static ImageIdenticalConstraint IdenticalTo(byte[] expected, double similarityThreshold = 98.0)
         => new(expected, similarityThreshold);
 
@@ -22,16 +19,14 @@ public static class IsImage
 
 public class ImageIdenticalConstraint : Constraint
 {
-    private readonly byte[] _expected;
-    private readonly double _similarityThreshold;
-    private double _actualSimilarity;
-    private static readonly AverageHash HashAlgorithm = new();
-
+    private readonly byte[] m_Expected;
+    private readonly double m_SimilarityThreshold;
+    private double m_ActualSimilarity;
     public ImageIdenticalConstraint(byte[] expected, double similarityThreshold)
     {
-        _expected = expected;
-        _similarityThreshold = similarityThreshold;
-        _actualSimilarity = -1;
+        m_Expected = expected;
+        m_SimilarityThreshold = similarityThreshold;
+        m_ActualSimilarity = -1;
     }
 
     public override ConstraintResult ApplyTo<TActual>(TActual actual)
@@ -44,16 +39,17 @@ public class ImageIdenticalConstraint : Constraint
         };
 
         using var actualMs = new MemoryStream(actualBytes);
-        using var expectedMs = new MemoryStream(_expected);
+        using var expectedMs = new MemoryStream(m_Expected);
 
-        var actualHash = HashAlgorithm.Hash(actualMs);
-        var expectedHash = HashAlgorithm.Hash(expectedMs);
+        var hashAlgorithm = new AverageHash();
+        var actualHash = hashAlgorithm.Hash(actualMs);
+        var expectedHash = hashAlgorithm.Hash(expectedMs);
 
-        _actualSimilarity = CompareHash.Similarity(actualHash, expectedHash);
+        m_ActualSimilarity = CompareHash.Similarity(actualHash, expectedHash);
 
-        var isSuccess = _actualSimilarity >= _similarityThreshold;
+        var isSuccess = m_ActualSimilarity >= m_SimilarityThreshold;
 
-        return new ImageConstraintResult(this, actual, isSuccess, _actualSimilarity, _similarityThreshold);
+        return new ImageConstraintResult(this, actual, isSuccess, m_ActualSimilarity, m_SimilarityThreshold);
     }
 
     private static byte[] ReadStream(Stream stream)
@@ -64,25 +60,25 @@ public class ImageIdenticalConstraint : Constraint
     }
 
     public override string Description
-        => $"image with >= {_similarityThreshold}% perceptual similarity to golden image";
+        => $"image with >= {m_SimilarityThreshold}% perceptual similarity to golden image";
 
     private class ImageConstraintResult : ConstraintResult
     {
-        private readonly double _similarity;
-        private readonly double _threshold;
+        private readonly double m_Similarity;
+        private readonly double m_Threshold;
 
         public ImageConstraintResult(IConstraint constraint, object? actualValue, bool isSuccess,
             double similarity, double threshold)
             : base(constraint, actualValue, isSuccess)
         {
-            _similarity = similarity;
-            _threshold = threshold;
+            m_Similarity = similarity;
+            m_Threshold = threshold;
         }
 
         public override void WriteMessageTo(MessageWriter writer)
         {
-            writer.Write($"Expected image to have >= {_threshold}% perceptual similarity to golden image, " +
-                         $"but similarity was {_similarity:F2}%.");
+            writer.Write($"Expected image to have >= {m_Threshold}% perceptual similarity to golden image, " +
+                         $"but similarity was {m_Similarity:F2}%.");
         }
     }
 }

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Extensions/ImageAssertExtensions.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Extensions/ImageAssertExtensions.cs
@@ -1,0 +1,88 @@
+using CoenM.ImageHash;
+using CoenM.ImageHash.HashAlgorithms;
+using NUnit.Framework.Constraints;
+using SixLabors.ImageSharp;
+
+namespace Mehrak.Application.Tests.Extensions;
+
+public static class IsImage
+{
+    private static readonly AverageHash HashAlgorithm = new();
+
+    public static ImageIdenticalConstraint IdenticalTo(byte[] expected, double similarityThreshold = 98.0)
+        => new(expected, similarityThreshold);
+
+    public static ImageIdenticalConstraint IdenticalTo(Stream expected, double similarityThreshold = 98.0)
+    {
+        using var ms = new MemoryStream();
+        expected.CopyTo(ms);
+        return new(ms.ToArray(), similarityThreshold);
+    }
+}
+
+public class ImageIdenticalConstraint : Constraint
+{
+    private readonly byte[] _expected;
+    private readonly double _similarityThreshold;
+    private double _actualSimilarity;
+    private static readonly AverageHash HashAlgorithm = new();
+
+    public ImageIdenticalConstraint(byte[] expected, double similarityThreshold)
+    {
+        _expected = expected;
+        _similarityThreshold = similarityThreshold;
+        _actualSimilarity = -1;
+    }
+
+    public override ConstraintResult ApplyTo<TActual>(TActual actual)
+    {
+        byte[] actualBytes = actual switch
+        {
+            byte[] bytes => bytes,
+            Stream stream => ReadStream(stream),
+            _ => throw new ArgumentException($"Expected byte[] or Stream, got {typeof(TActual)}")
+        };
+
+        using var actualMs = new MemoryStream(actualBytes);
+        using var expectedMs = new MemoryStream(_expected);
+
+        var actualHash = HashAlgorithm.Hash(actualMs);
+        var expectedHash = HashAlgorithm.Hash(expectedMs);
+
+        _actualSimilarity = CompareHash.Similarity(actualHash, expectedHash);
+
+        var isSuccess = _actualSimilarity >= _similarityThreshold;
+
+        return new ImageConstraintResult(this, actual, isSuccess, _actualSimilarity, _similarityThreshold);
+    }
+
+    private static byte[] ReadStream(Stream stream)
+    {
+        using var ms = new MemoryStream();
+        stream.CopyTo(ms);
+        return ms.ToArray();
+    }
+
+    public override string Description
+        => $"image with >= {_similarityThreshold}% perceptual similarity to golden image";
+
+    private class ImageConstraintResult : ConstraintResult
+    {
+        private readonly double _similarity;
+        private readonly double _threshold;
+
+        public ImageConstraintResult(IConstraint constraint, object? actualValue, bool isSuccess,
+            double similarity, double threshold)
+            : base(constraint, actualValue, isSuccess)
+        {
+            _similarity = similarity;
+            _threshold = threshold;
+        }
+
+        public override void WriteMessageTo(MessageWriter writer)
+        {
+            writer.Write($"Expected image to have >= {_threshold}% perceptual similarity to golden image, " +
+                         $"but similarity was {_similarity:F2}%.");
+        }
+    }
+}

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Mehrak.Application.Tests.csproj
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Mehrak.Application.Tests.csproj
@@ -38,6 +38,8 @@
         <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
         <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
         <PackageReference Include="Testcontainers.LocalStack" Version="4.11.0" />
+        <PackageReference Include="CoenM.ImageSharp.ImageHash" Version="1.3.6" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
     </ItemGroup>
 
     <ItemGroup>

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Genshin/Abyss/GenshinAbyssCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Genshin/Abyss/GenshinAbyssCardServiceTests.cs
@@ -78,7 +78,8 @@ public class GenshinAbyssCardServiceTests
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImage);
 
         Assert.That(bytes, Is.Not.Empty);
-        Assert.That(bytes, IsImage.IdenticalTo(goldenImage));
+        using var goldenStream = new MemoryStream(goldenImage);
+        Assert.That(memoryStream, IsImage.IdenticalTo(goldenStream));
     }
 
     private static GameProfileDto GetTestUserGameData()

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Genshin/Abyss/GenshinAbyssCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Genshin/Abyss/GenshinAbyssCardServiceTests.cs
@@ -3,6 +3,7 @@
 using System.Text.Json;
 using Mehrak.Application.Services.Common.Types;
 using Mehrak.Application.Services.Genshin.Abyss;
+using Mehrak.Application.Tests.Extensions;
 using Mehrak.Domain.Enums;
 using Mehrak.Domain.Models;
 using Mehrak.GameApi.Genshin.Types;
@@ -77,7 +78,7 @@ public class GenshinAbyssCardServiceTests
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImage);
 
         Assert.That(bytes, Is.Not.Empty);
-        Assert.That(bytes, Is.EqualTo(goldenImage));
+        Assert.That(bytes, IsImage.IdenticalTo(goldenImage));
     }
 
     private static GameProfileDto GetTestUserGameData()

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Genshin/CharList/GenshinCharListCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Genshin/CharList/GenshinCharListCardServiceTests.cs
@@ -3,6 +3,7 @@
 using System.Text.Json;
 using Mehrak.Application.Services.Common.Types;
 using Mehrak.Application.Services.Genshin.CharList;
+using Mehrak.Application.Tests.Extensions;
 using Mehrak.Domain.Enums;
 using Mehrak.Domain.Models;
 using Mehrak.GameApi.Genshin.Types;
@@ -75,7 +76,7 @@ public class GenshinCharListCardServiceTests
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImage);
 
         Assert.That(bytes, Is.Not.Empty);
-        Assert.That(bytes, Is.EqualTo(goldenImage));
+        Assert.That(bytes, IsImage.IdenticalTo(goldenImage));
     }
 
     private static GameProfileDto GetTestUserGameData()

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Genshin/CharList/GenshinCharListCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Genshin/CharList/GenshinCharListCardServiceTests.cs
@@ -76,7 +76,8 @@ public class GenshinCharListCardServiceTests
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImage);
 
         Assert.That(bytes, Is.Not.Empty);
-        Assert.That(bytes, IsImage.IdenticalTo(goldenImage));
+        using var goldenStream = new MemoryStream(goldenImage);
+        Assert.That(memoryStream, IsImage.IdenticalTo(goldenStream));
     }
 
     private static GameProfileDto GetTestUserGameData()

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Genshin/Character/GenshinCharacterCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Genshin/Character/GenshinCharacterCardServiceTests.cs
@@ -3,6 +3,7 @@
 using System.Text.Json;
 using Mehrak.Application.Services.Common.Types;
 using Mehrak.Application.Services.Genshin.Character;
+using Mehrak.Application.Tests.Extensions;
 using Mehrak.Domain.Enums;
 using Mehrak.Domain.Models;
 using Mehrak.GameApi.Genshin.Types;
@@ -73,7 +74,7 @@ public class GenshinCharacterCardServiceTests
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImage);
 
         // Assert
-        Assert.That(file.ToArray(), Is.EqualTo(goldenImage));
+        Assert.That(file.ToArray(), IsImage.IdenticalTo(goldenImage));
     }
 
     [Test]
@@ -111,7 +112,7 @@ public class GenshinCharacterCardServiceTests
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImage);
 
         // Assert
-        Assert.That(file.ToArray(), Is.EqualTo(goldenImage));
+        Assert.That(file.ToArray(), IsImage.IdenticalTo(goldenImage));
     }
 
     private static GameProfileDto GetTestUserGameData()

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Genshin/Character/GenshinCharacterCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Genshin/Character/GenshinCharacterCardServiceTests.cs
@@ -74,7 +74,9 @@ public class GenshinCharacterCardServiceTests
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImage);
 
         // Assert
-        Assert.That(file.ToArray(), IsImage.IdenticalTo(goldenImage));
+        file.Position = 0;
+        using var goldenStream = new MemoryStream(goldenImage);
+        Assert.That(file, IsImage.IdenticalTo(goldenStream));
     }
 
     [Test]
@@ -112,7 +114,9 @@ public class GenshinCharacterCardServiceTests
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImage);
 
         // Assert
-        Assert.That(file.ToArray(), IsImage.IdenticalTo(goldenImage));
+        file.Position = 0;
+        using var goldenStream2 = new MemoryStream(goldenImage);
+        Assert.That(file, IsImage.IdenticalTo(goldenStream2));
     }
 
     private static GameProfileDto GetTestUserGameData()

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Genshin/Stygian/GenshinStygianCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Genshin/Stygian/GenshinStygianCardServiceTests.cs
@@ -75,7 +75,8 @@ public class GenshinStygianCardServiceTests
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImage);
 
         Assert.That(bytes, Is.Not.Empty);
-        Assert.That(bytes, IsImage.IdenticalTo(goldenImage));
+        using var goldenStream = new MemoryStream(goldenImage);
+        Assert.That(memoryStream, IsImage.IdenticalTo(goldenStream));
     }
 
     private static GameProfileDto GetTestUserGameData()

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Genshin/Stygian/GenshinStygianCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Genshin/Stygian/GenshinStygianCardServiceTests.cs
@@ -3,6 +3,7 @@
 using System.Text.Json;
 using Mehrak.Application.Services.Common.Types;
 using Mehrak.Application.Services.Genshin.Stygian;
+using Mehrak.Application.Tests.Extensions;
 using Mehrak.Domain.Enums;
 using Mehrak.Domain.Models;
 using Mehrak.GameApi.Genshin.Types;
@@ -74,7 +75,7 @@ public class GenshinStygianCardServiceTests
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImage);
 
         Assert.That(bytes, Is.Not.Empty);
-        Assert.That(bytes, Is.EqualTo(goldenImage));
+        Assert.That(bytes, IsImage.IdenticalTo(goldenImage));
     }
 
     private static GameProfileDto GetTestUserGameData()

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Genshin/Theater/GenshinTheaterCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Genshin/Theater/GenshinTheaterCardServiceTests.cs
@@ -84,7 +84,8 @@ public class GenshinTheaterCardServiceTests
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImage);
 
         Assert.That(bytes, Is.Not.Empty);
-        Assert.That(bytes, IsImage.IdenticalTo(goldenImage));
+        using var goldenStream = new MemoryStream(goldenImage);
+        Assert.That(memoryStream, IsImage.IdenticalTo(goldenStream));
     }
 
     private static GameProfileDto GetTestUserGameData()

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Genshin/Theater/GenshinTheaterCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Genshin/Theater/GenshinTheaterCardServiceTests.cs
@@ -3,6 +3,7 @@
 using System.Text.Json;
 using Mehrak.Application.Services.Common.Types;
 using Mehrak.Application.Services.Genshin.Theater;
+using Mehrak.Application.Tests.Extensions;
 using Mehrak.Domain.Enums;
 using Mehrak.Domain.Models;
 using Mehrak.GameApi.Genshin.Types;
@@ -83,7 +84,7 @@ public class GenshinTheaterCardServiceTests
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImage);
 
         Assert.That(bytes, Is.Not.Empty);
-        Assert.That(bytes, Is.EqualTo(goldenImage));
+        Assert.That(bytes, IsImage.IdenticalTo(goldenImage));
     }
 
     private static GameProfileDto GetTestUserGameData()

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Hi3/Character/Hi3CharacterCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Hi3/Character/Hi3CharacterCardServiceTests.cs
@@ -2,6 +2,7 @@
 using System.Text.Json.Serialization;
 using Mehrak.Application.Services.Common.Types;
 using Mehrak.Application.Services.Hi3.Character;
+using Mehrak.Application.Tests.Extensions;
 using Mehrak.Domain.Common;
 using Mehrak.Domain.Enums;
 using Mehrak.Domain.Models;
@@ -162,7 +163,7 @@ internal class Hi3CharacterCardServiceTests
         var outputGoldenImagePath = Path.Combine(outputDirectory, $"{testName}_Golden.jpg");
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImageBytes);
 
-        Assert.That(generatedImageBytes, Is.EqualTo(goldenImageBytes),
+        Assert.That(generatedImageBytes, IsImage.IdenticalTo(goldenImageBytes),
             $"Generated image should match golden image for {testName}");
     }
 

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Hi3/Character/Hi3CharacterCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Hi3/Character/Hi3CharacterCardServiceTests.cs
@@ -163,7 +163,9 @@ internal class Hi3CharacterCardServiceTests
         var outputGoldenImagePath = Path.Combine(outputDirectory, $"{testName}_Golden.jpg");
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImageBytes);
 
-        Assert.That(generatedImageBytes, IsImage.IdenticalTo(goldenImageBytes),
+        memoryStream.Position = 0;
+        using var goldenStream = new MemoryStream(goldenImageBytes);
+        Assert.That(memoryStream, IsImage.IdenticalTo(goldenStream),
             $"Generated image should match golden image for {testName}");
     }
 

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Hsr/Anomaly/HsrAnomalyCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Hsr/Anomaly/HsrAnomalyCardServiceTests.cs
@@ -62,7 +62,8 @@ internal class HsrAnomalyCardServiceTests
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImage);
 
         Assert.That(bytes, Is.Not.Empty);
-        Assert.That(bytes, IsImage.IdenticalTo(goldenImage));
+        using var goldenStream = new MemoryStream(goldenImage);
+        Assert.That(memStream, IsImage.IdenticalTo(goldenStream));
     }
 
     private static GameProfileDto GetTestUserGameData()

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Hsr/Anomaly/HsrAnomalyCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Hsr/Anomaly/HsrAnomalyCardServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.Json;
 using Mehrak.Application.Services.Common.Types;
 using Mehrak.Application.Services.Hsr.Anomaly;
+using Mehrak.Application.Tests.Extensions;
 using Mehrak.Domain.Enums;
 using Mehrak.Domain.Models;
 using Mehrak.GameApi.Hsr.Types;
@@ -61,7 +62,7 @@ internal class HsrAnomalyCardServiceTests
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImage);
 
         Assert.That(bytes, Is.Not.Empty);
-        Assert.That(bytes, Is.EqualTo(goldenImage));
+        Assert.That(bytes, IsImage.IdenticalTo(goldenImage));
     }
 
     private static GameProfileDto GetTestUserGameData()

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Hsr/CharList/HsrCharListCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Hsr/CharList/HsrCharListCardServiceTests.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Mehrak.Application.Services.Common.Types;
 using Mehrak.Application.Services.Hsr.CharList;
+using Mehrak.Application.Tests.Extensions;
 using Mehrak.Domain.Enums;
 using Mehrak.Domain.Models;
 using Mehrak.GameApi.Hsr.Types;
@@ -77,7 +78,7 @@ public class HsrCharListCardServiceTests
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImage);
 
         Assert.That(bytes, Is.Not.Empty);
-        Assert.That(bytes, Is.EqualTo(goldenImage), "Generated image should match the golden image");
+        Assert.That(bytes, IsImage.IdenticalTo(goldenImage), "Generated image should match the golden image");
     }
 
     private static GameProfileDto GetTestUserGameData()

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Hsr/CharList/HsrCharListCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Hsr/CharList/HsrCharListCardServiceTests.cs
@@ -78,7 +78,8 @@ public class HsrCharListCardServiceTests
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImage);
 
         Assert.That(bytes, Is.Not.Empty);
-        Assert.That(bytes, IsImage.IdenticalTo(goldenImage), "Generated image should match the golden image");
+        using var goldenStream = new MemoryStream(goldenImage);
+        Assert.That(memoryStream, IsImage.IdenticalTo(goldenStream), "Generated image should match the golden image");
     }
 
     private static GameProfileDto GetTestUserGameData()

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Hsr/Character/HsrCharacterCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Hsr/Character/HsrCharacterCardServiceTests.cs
@@ -3,6 +3,7 @@
 using System.Text.Json;
 using Mehrak.Application.Services.Common.Types;
 using Mehrak.Application.Services.Hsr.Character;
+using Mehrak.Application.Tests.Extensions;
 using Mehrak.Domain.Enums;
 using Mehrak.Domain.Models;
 using Mehrak.GameApi.Hsr.Types;
@@ -130,7 +131,7 @@ public class HsrCharacterCardServiceTests
         var outputGoldenImagePath = Path.Combine(outputDirectory, $"{testName}_Golden.jpg");
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImageBytes);
 
-        Assert.That(generatedImageBytes, Is.EqualTo(goldenImageBytes),
+        Assert.That(generatedImageBytes, IsImage.IdenticalTo(goldenImageBytes),
             $"Generated image should match golden image for {testName}");
     }
 

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Hsr/Character/HsrCharacterCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Hsr/Character/HsrCharacterCardServiceTests.cs
@@ -131,7 +131,9 @@ public class HsrCharacterCardServiceTests
         var outputGoldenImagePath = Path.Combine(outputDirectory, $"{testName}_Golden.jpg");
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImageBytes);
 
-        Assert.That(generatedImageBytes, IsImage.IdenticalTo(goldenImageBytes),
+        memoryStream.Position = 0;
+        using var goldenStream = new MemoryStream(goldenImageBytes);
+        Assert.That(memoryStream, IsImage.IdenticalTo(goldenStream),
             $"Generated image should match golden image for {testName}");
     }
 

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Hsr/EndGame/HsrEndGameCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Hsr/EndGame/HsrEndGameCardServiceTests.cs
@@ -74,7 +74,8 @@ public class HsrPureFictionCardServiceTests
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImage);
 
         Assert.That(bytes, Is.Not.Empty);
-        Assert.That(bytes, IsImage.IdenticalTo(goldenImage));
+        using var goldenStream = new MemoryStream(goldenImage);
+        Assert.That(memoryStream, IsImage.IdenticalTo(goldenStream));
     }
 
     [Explicit]
@@ -180,7 +181,8 @@ public class HsrApocalypticShadowCardServiceTests
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImage);
 
         Assert.That(bytes, Is.Not.Empty);
-        Assert.That(bytes, IsImage.IdenticalTo(goldenImage));
+        using var goldenStreamAs = new MemoryStream(goldenImage);
+        Assert.That(memoryStream, IsImage.IdenticalTo(goldenStreamAs));
     }
 
     [Explicit]

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Hsr/EndGame/HsrEndGameCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Hsr/EndGame/HsrEndGameCardServiceTests.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Mehrak.Application.Services.Common.Types;
 using Mehrak.Application.Services.Hsr.EndGame;
+using Mehrak.Application.Tests.Extensions;
 using Mehrak.Domain.Models;
 using Mehrak.GameApi.Hsr.Types;
 using Microsoft.Extensions.Logging;
@@ -73,7 +74,7 @@ public class HsrPureFictionCardServiceTests
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImage);
 
         Assert.That(bytes, Is.Not.Empty);
-        Assert.That(bytes, Is.EqualTo(goldenImage));
+        Assert.That(bytes, IsImage.IdenticalTo(goldenImage));
     }
 
     [Explicit]
@@ -179,7 +180,7 @@ public class HsrApocalypticShadowCardServiceTests
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImage);
 
         Assert.That(bytes, Is.Not.Empty);
-        Assert.That(bytes, Is.EqualTo(goldenImage));
+        Assert.That(bytes, IsImage.IdenticalTo(goldenImage));
     }
 
     [Explicit]

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Hsr/Memory/HsrMemoryCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Hsr/Memory/HsrMemoryCardServiceTests.cs
@@ -79,7 +79,8 @@ public class HsrMemoryCardServiceTests
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImage);
 
         Assert.That(bytes, Is.Not.Empty);
-        Assert.That(bytes, IsImage.IdenticalTo(goldenImage));
+        using var goldenStream = new MemoryStream(goldenImage);
+        Assert.That(memoryStream, IsImage.IdenticalTo(goldenStream));
     }
 
     private static GameProfileDto GetTestUserGameData()

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Hsr/Memory/HsrMemoryCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Hsr/Memory/HsrMemoryCardServiceTests.cs
@@ -3,6 +3,7 @@
 using System.Text.Json;
 using Mehrak.Application.Services.Common.Types;
 using Mehrak.Application.Services.Hsr.Memory;
+using Mehrak.Application.Tests.Extensions;
 using Mehrak.Domain.Enums;
 using Mehrak.Domain.Models;
 using Mehrak.GameApi.Hsr.Types;
@@ -78,7 +79,7 @@ public class HsrMemoryCardServiceTests
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImage);
 
         Assert.That(bytes, Is.Not.Empty);
-        Assert.That(bytes, Is.EqualTo(goldenImage));
+        Assert.That(bytes, IsImage.IdenticalTo(goldenImage));
     }
 
     private static GameProfileDto GetTestUserGameData()

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Zzz/Assault/ZzzAssaultCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Zzz/Assault/ZzzAssaultCardServiceTests.cs
@@ -74,7 +74,9 @@ public class ZzzAssaultCardServiceTests
             $"ZzzAssault_Data{Path.GetFileNameWithoutExtension(testData).Last()}_Golden.jpg");
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImage);
 
-        Assert.That(generatedImageBytes, IsImage.IdenticalTo(goldenImage), "Generated image should match the golden image");
+        Assert.That(generatedImageBytes, Is.Not.Empty);
+        using var goldenStream = new MemoryStream(goldenImage);
+        Assert.That(memoryStream, IsImage.IdenticalTo(goldenStream), "Generated image should match the golden image");
     }
 
     private static GameProfileDto GetTestUserGameData()

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Zzz/Assault/ZzzAssaultCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Zzz/Assault/ZzzAssaultCardServiceTests.cs
@@ -3,6 +3,7 @@
 using System.Text.Json;
 using Mehrak.Application.Services.Common.Types;
 using Mehrak.Application.Services.Zzz.Assault;
+using Mehrak.Application.Tests.Extensions;
 using Mehrak.Domain.Enums;
 using Mehrak.Domain.Models;
 using Mehrak.GameApi.Zzz.Types;
@@ -73,7 +74,7 @@ public class ZzzAssaultCardServiceTests
             $"ZzzAssault_Data{Path.GetFileNameWithoutExtension(testData).Last()}_Golden.jpg");
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImage);
 
-        Assert.That(generatedImageBytes, Is.EqualTo(goldenImage), "Generated image should match the golden image");
+        Assert.That(generatedImageBytes, IsImage.IdenticalTo(goldenImage), "Generated image should match the golden image");
     }
 
     private static GameProfileDto GetTestUserGameData()

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Zzz/CharList/ZzzCharacterCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Zzz/CharList/ZzzCharacterCardServiceTests.cs
@@ -82,7 +82,9 @@ public class ZzzCharListCardServiceTests
         var outputGoldenImagePath = Path.Combine(outputDirectory, $"ZZZ_{testName}_Golden.jpg");
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImage);
 
-        Assert.That(generatedImageBytes, IsImage.IdenticalTo(goldenImage), "Generated image should match the golden image");
+        Assert.That(generatedImageBytes, Is.Not.Empty);
+        using var goldenStream = new MemoryStream(goldenImage);
+        Assert.That(memoryStream, IsImage.IdenticalTo(goldenStream), "Generated image should match the golden image");
     }
 
     private static GameProfileDto GetTestUserGameData()

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Zzz/CharList/ZzzCharacterCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Zzz/CharList/ZzzCharacterCardServiceTests.cs
@@ -3,6 +3,7 @@
 using System.Text.Json;
 using Mehrak.Application.Services.Common.Types;
 using Mehrak.Application.Services.Zzz.CharList;
+using Mehrak.Application.Tests.Extensions;
 using Mehrak.Domain.Enums;
 using Mehrak.Domain.Models;
 using Mehrak.GameApi.Zzz.Types;
@@ -81,7 +82,7 @@ public class ZzzCharListCardServiceTests
         var outputGoldenImagePath = Path.Combine(outputDirectory, $"ZZZ_{testName}_Golden.jpg");
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImage);
 
-        Assert.That(generatedImageBytes, Is.EqualTo(goldenImage), "Generated image should match the golden image");
+        Assert.That(generatedImageBytes, IsImage.IdenticalTo(goldenImage), "Generated image should match the golden image");
     }
 
     private static GameProfileDto GetTestUserGameData()

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Zzz/Character/ZzzCharacterCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Zzz/Character/ZzzCharacterCardServiceTests.cs
@@ -3,6 +3,7 @@
 using System.Text.Json;
 using Mehrak.Application.Services.Common.Types;
 using Mehrak.Application.Services.Zzz.Character;
+using Mehrak.Application.Tests.Extensions;
 using Mehrak.Domain.Enums;
 using Mehrak.Domain.Models;
 using Mehrak.GameApi.Zzz.Types;
@@ -73,7 +74,7 @@ public class ZzzCharacterCardServiceTests
         var outputGoldenImagePath = Path.Combine(outputDirectory, $"{testName}_Golden.jpg");
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImage);
 
-        Assert.That(generatedImageBytes, Is.EqualTo(goldenImage), "Generated image should match the golden image");
+        Assert.That(generatedImageBytes, IsImage.IdenticalTo(goldenImage), "Generated image should match the golden image");
     }
 
     private static GameProfileDto GetTestUserGameData()

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Zzz/Character/ZzzCharacterCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Zzz/Character/ZzzCharacterCardServiceTests.cs
@@ -74,7 +74,9 @@ public class ZzzCharacterCardServiceTests
         var outputGoldenImagePath = Path.Combine(outputDirectory, $"{testName}_Golden.jpg");
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImage);
 
-        Assert.That(generatedImageBytes, IsImage.IdenticalTo(goldenImage), "Generated image should match the golden image");
+        Assert.That(generatedImageBytes, Is.Not.Empty);
+        using var goldenStream = new MemoryStream(goldenImage);
+        Assert.That(memoryStream, IsImage.IdenticalTo(goldenStream), "Generated image should match the golden image");
     }
 
     private static GameProfileDto GetTestUserGameData()

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Zzz/Defense/ZzzDefenseCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Zzz/Defense/ZzzDefenseCardServiceTests.cs
@@ -76,7 +76,9 @@ public class ZzzDefenseCardServiceTests
             $"ZzzDefense_Data{Path.GetFileNameWithoutExtension(testData).Last()}_Golden.jpg");
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImage);
 
-        Assert.That(generatedImageBytes, IsImage.IdenticalTo(goldenImage), "Generated image should match the golden image");
+        Assert.That(generatedImageBytes, Is.Not.Empty);
+        using var goldenStream = new MemoryStream(goldenImage);
+        Assert.That(memoryStream, IsImage.IdenticalTo(goldenStream), "Generated image should match the golden image");
     }
 
     private static GameProfileDto GetTestUserGameData()

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Zzz/Defense/ZzzDefenseCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Zzz/Defense/ZzzDefenseCardServiceTests.cs
@@ -3,6 +3,7 @@
 using System.Text.Json;
 using Mehrak.Application.Services.Common.Types;
 using Mehrak.Application.Services.Zzz.Defense;
+using Mehrak.Application.Tests.Extensions;
 using Mehrak.Domain.Enums;
 using Mehrak.Domain.Models;
 using Mehrak.GameApi.Zzz.Types;
@@ -75,7 +76,7 @@ public class ZzzDefenseCardServiceTests
             $"ZzzDefense_Data{Path.GetFileNameWithoutExtension(testData).Last()}_Golden.jpg");
         await File.WriteAllBytesAsync(outputGoldenImagePath, goldenImage);
 
-        Assert.That(generatedImageBytes, Is.EqualTo(goldenImage), "Generated image should match the golden image");
+        Assert.That(generatedImageBytes, IsImage.IdenticalTo(goldenImage), "Generated image should match the golden image");
     }
 
     private static GameProfileDto GetTestUserGameData()

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Zzz/Tower/ZzzTowerCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Zzz/Tower/ZzzTowerCardServiceTests.cs
@@ -89,7 +89,7 @@ public class ZzzTowerCardServiceTests
         using MemoryStream imageMs = new();
         await image.CopyToAsync(imageMs);
 
-        Assert.That(imageMs.ToArray(), IsImage.IdenticalTo(goldenMs.ToArray()), "Generated image should match the golden image");
+        Assert.That(imageMs, IsImage.IdenticalTo(goldenMs), "Generated image should match the golden image");
     }
 
     [Explicit]

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Zzz/Tower/ZzzTowerCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Services/Zzz/Tower/ZzzTowerCardServiceTests.cs
@@ -2,6 +2,7 @@
 using Mehrak.Application.Services.Abstractions;
 using Mehrak.Application.Services.Common.Types;
 using Mehrak.Application.Services.Zzz.Tower;
+using Mehrak.Application.Tests.Extensions;
 using Mehrak.Domain.Enums;
 using Mehrak.Domain.Models;
 using Mehrak.GameApi.Zzz.Types;
@@ -82,7 +83,13 @@ public class ZzzTowerCardServiceTests
 
         goldenImage.Position = 0;
         image.Position = 0;
-        Assert.That(image, Is.EqualTo(goldenImage), "Generated image should match the golden image");
+
+        using MemoryStream goldenMs = new();
+        await goldenImage.CopyToAsync(goldenMs);
+        using MemoryStream imageMs = new();
+        await image.CopyToAsync(imageMs);
+
+        Assert.That(imageMs.ToArray(), IsImage.IdenticalTo(goldenMs.ToArray()), "Generated image should match the golden image");
     }
 
     [Explicit]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added image similarity assertion framework for more robust visual validation in tests.
  * Updated card service tests to use perceptual image matching instead of strict byte comparison, reducing false failures while maintaining quality verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->