### PR TITLE
Remove markdown escape for titles

### DIFF
--- a/MehrakBot/Services/Bot/Mehrak.Bot/Services/HylEmbedService.cs
+++ b/MehrakBot/Services/Bot/Mehrak.Bot/Services/HylEmbedService.cs
@@ -89,7 +89,7 @@ internal partial class HylEmbedService : IBotService
             : $"-# HoYoLAB · <t:{post.Post.CreatedAt}:F>";
 
         var container = new ComponentContainerProperties()
-            .AddComponents(new TextDisplayProperties($"## [{EscapeMarkdown(post.Post.Subject)}](https://www.hoyolab.com/article/{post.Post.PostId})"));
+            .AddComponents(new TextDisplayProperties($"## [{post.Post.Subject}](https://www.hoyolab.com/article/{post.Post.PostId})"));
 
         var components = BuildComponents(inserts, locale, post.Post.PostId);
         m_Logger.LogInformation("Built {ComponentCount} components for post {PostId}", components.Count, post.Post.PostId);
@@ -164,7 +164,7 @@ internal partial class HylEmbedService : IBotService
                     var articleCard = articleCards[i];
                     var title = articleCard.Info.Title;
                     var nickname = articleCard.User.Nickname;
-                    var content = $"{EscapeMarkdown(title)}\n-# {nickname}";
+                    var content = $"{title}\n-# {nickname}";
                     var section = new ComponentSectionProperties(
                         new LinkButtonProperties(articleButton, $"https://www.hoyolab.com/article/{articleCard.Meta.MetaId}"),
                         [new TextDisplayProperties(content)]);
@@ -184,7 +184,7 @@ internal partial class HylEmbedService : IBotService
             {
                 var section = new ComponentSectionProperties(
                     new LinkButtonProperties(voteButton, articleUrl),
-                    [new TextDisplayProperties(EscapeMarkdown(vote.Title))]);
+                    [new TextDisplayProperties(vote.Title)]);
                 components.Add(section);
                 currentLength += vote.Title.Length;
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect display of HoYoLAB post subjects, article titles, and vote titles in Discord embeds by correcting how special characters are rendered.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GamerYuan/MehrakBot/pull/184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->