### PR TITLE
Add starward mode support for HSR PF and AS

### DIFF
--- a/MehrakBot/Common/Mehrak.Domain/Image/Models/FileNameFormat.cs
+++ b/MehrakBot/Common/Mehrak.Domain/Image/Models/FileNameFormat.cs
@@ -58,6 +58,7 @@ public static class FileNameFormat
         public const string LightconeTemplateName = "hsr/lightcone_template.png";
         public const string RelicTemplateName = "hsr/relic_template_{0}.png";
         public const string BackgroundName = "hsr/bg.png";
+        public const string ExtraStarName = "hsr/starward_star.png";
     }
 
     public static class Zzz

--- a/MehrakBot/Common/Mehrak.GameApi/Hsr/Types/HsrEndInformation.cs
+++ b/MehrakBot/Common/Mehrak.GameApi/Hsr/Types/HsrEndInformation.cs
@@ -20,9 +20,15 @@ public class HsrEndFloorDetail
 
     [JsonPropertyName("node_2")] public HsrEndNodeInformation? Node2 { get; set; }
 
+    [JsonPropertyName("node_3")] public HsrEndNodeInformation? Node3 { get; set; }
+
     [JsonPropertyName("maze_id")] public int MazeId { get; set; }
 
     [JsonPropertyName("is_fast")] public bool IsFast { get; set; }
+
+    [JsonPropertyName("extra_star_num")] public int ExtraStarNum { get; set; }
+
+    [JsonPropertyName("is_tierce")] public bool IsTierce { get; set; }
 }
 
 public class HsrEndAvatar
@@ -116,6 +122,8 @@ public class HsrEndInformation
     [JsonPropertyName("all_floor_detail")] public required List<HsrEndFloorDetail> AllFloorDetail { get; set; }
 
     [JsonPropertyName("max_floor_id")] public int MaxFloorId { get; set; }
+
+    [JsonPropertyName("extra_star_num")] public int ExtraStarNum { get; set; }
 }
 
 public class ScheduleTime

--- a/MehrakBot/Common/Mehrak.GameApi/Hsr/Types/HsrEndInformation.cs
+++ b/MehrakBot/Common/Mehrak.GameApi/Hsr/Types/HsrEndInformation.cs
@@ -29,6 +29,9 @@ public class HsrEndFloorDetail
     [JsonPropertyName("extra_star_num")] public int ExtraStarNum { get; set; }
 
     [JsonPropertyName("is_tierce")] public bool IsTierce { get; set; }
+
+    [JsonIgnore]
+    public int TotalScore => (Node1?.Score ?? 0) + (Node2?.Score ?? 0) + (Node3?.Score ?? 0);
 }
 
 public class HsrEndAvatar
@@ -98,7 +101,7 @@ public class HsrEndNodeInformation
 
     [JsonPropertyName("buff")] public required HsrEndBuff Buff { get; set; }
 
-    [JsonPropertyName("score")] public required string Score { get; set; }
+    [JsonPropertyName("score")] public int Score { get; set; }
 
     /// <summary>
     /// Only used for Apocalyptic Shadow

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Hsr/EndGame/HsrEndGameCardServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Hsr/EndGame/HsrEndGameCardServiceTests.cs
@@ -24,6 +24,10 @@ public class HsrPureFictionCardServiceTests
     private const string TestNickName = "Test";
     private const string TestUid = "800000000";
     private const ulong TestUserId = 1;
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        NumberHandling = JsonNumberHandling.AllowReadingFromString
+    };
 
     private static readonly string TestDataPath = Path.Combine(AppContext.BaseDirectory, "TestData");
 
@@ -42,11 +46,13 @@ public class HsrPureFictionCardServiceTests
     [TestCase("Pf_TestData_2.json")]
     [TestCase("Pf_TestData_3.json")]
     [TestCase("Pf_TestData_4.json")]
+    [TestCase("Pf_TestData_5.json")]
+    [TestCase("Pf_TestData_6.json")]
     public async Task GetCardAsync_PureFictionTestData_MatchesGoldenImage(string testDataFileName)
     {
         var testData =
             await JsonSerializer.DeserializeAsync<HsrEndInformation>(
-                File.OpenRead(Path.Combine(TestDataPath, "Hsr", testDataFileName)));
+                File.OpenRead(Path.Combine(TestDataPath, "Hsr", testDataFileName)), JsonOptions);
         Assert.That(testData, Is.Not.Null, "Test data should not be null");
 
         var goldenImage =
@@ -86,10 +92,12 @@ public class HsrPureFictionCardServiceTests
     [TestCase("Pf_TestData_2.json", "Pf_GoldenImage_2.jpg")]
     [TestCase("Pf_TestData_3.json", "Pf_GoldenImage_3.jpg")]
     [TestCase("Pf_TestData_4.json", "Pf_GoldenImage_4.jpg")]
+    [TestCase("Pf_TestData_5.json", "Pf_GoldenImage_5.jpg")]
+    [TestCase("Pf_TestData_6.json", "Pf_GoldenImage_6.jpg")]
     public async Task GeneratePureFictionGoldenImage(string testDataFileName, string goldenImageFileName)
     {
         var testData = await JsonSerializer.DeserializeAsync<HsrEndInformation>(
-               File.OpenRead(Path.Combine(AppContext.BaseDirectory, "TestData", "Hsr", testDataFileName)));
+               File.OpenRead(Path.Combine(AppContext.BaseDirectory, "TestData", "Hsr", testDataFileName)), JsonOptions);
         Assert.That(testData, Is.Not.Null);
 
         var userGameData = GetTestUserGameData();
@@ -149,6 +157,8 @@ public class HsrApocalypticShadowCardServiceTests
     [TestCase("As_TestData_2.json")]
     [TestCase("As_TestData_3.json")]
     [TestCase("As_TestData_4.json")]
+    [TestCase("As_TestData_5.json")]
+    [TestCase("As_TestData_6.json")]
     public async Task GetCardAsync_ApocalypticShadowTestData_MatchesGoldenImage(string testDataFileName)
     {
         var testData =
@@ -193,6 +203,8 @@ public class HsrApocalypticShadowCardServiceTests
     [TestCase("As_TestData_2.json", "As_GoldenImage_2.jpg")]
     [TestCase("As_TestData_3.json", "As_GoldenImage_3.jpg")]
     [TestCase("As_TestData_4.json", "As_GoldenImage_4.jpg")]
+    [TestCase("As_TestData_5.json", "As_GoldenImage_5.jpg")]
+    [TestCase("As_TestData_6.json", "As_GoldenImage_6.jpg")]
     public async Task GenerateApocalypticShadowGoldenImage(string testDataFileName, string goldenImageFileName)
     {
         var testData = await JsonSerializer.DeserializeAsync<HsrEndInformation>(

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/TestData/Hsr/As_TestData_5.json
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/TestData/Hsr/As_TestData_5.json
@@ -1,0 +1,490 @@
+﻿{
+  "groups": [
+    {
+      "schedule_id": 3018,
+      "begin_time": {
+        "year": 2026,
+        "month": 6,
+        "day": 8,
+        "hour": 4,
+        "minute": 0
+      },
+      "end_time": {
+        "year": 2026,
+        "month": 7,
+        "day": 20,
+        "hour": 4,
+        "minute": 0
+      },
+      "status": "New",
+      "name_mi18n": "Gale of Forgetting",
+      "upper_boss": {
+        "id": 406401204,
+        "name_mi18n": "Arbiter of the Lost Abyss",
+        "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u0a0ae/dcda8f05c05abb87ea74737334d937b5.png"
+      },
+      "lower_boss": {
+        "id": 100401404,
+        "name_mi18n": "Annihilator of Desolation Mistral",
+        "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u0a0ae/50a52a7175589ddcc09b2640b5774f7f.png"
+      },
+      "tierce_boss": {
+        "id": 403401304,
+        "name_mi18n": "Flame Reaver of Doomsday Led Astray",
+        "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u0a0ae/f56b520a4f35f96c07127231a3bd0548.png"
+      }
+    },
+    {
+      "schedule_id": 3017,
+      "begin_time": {
+        "year": 2026,
+        "month": 4,
+        "day": 27,
+        "hour": 4,
+        "minute": 0
+      },
+      "end_time": {
+        "year": 2026,
+        "month": 6,
+        "day": 8,
+        "hour": 4,
+        "minute": 0
+      },
+      "status": "End",
+      "name_mi18n": "Idol of the Locusts",
+      "upper_boss": {
+        "id": 501401404,
+        "name_mi18n": "Super Idol: Center of Attention",
+        "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u0a0ae/eb458e94ee9f053173327981bbebdd4c.png"
+      },
+      "lower_boss": {
+        "id": 802501104,
+        "name_mi18n": "Sky-Shrouding Stardevourer Swarm",
+        "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u0a0ae/f2e2fd5880642f27bf25b6a71d975ce1.png"
+      },
+      "tierce_boss": null
+    }
+  ],
+  "star_num": 9,
+  "max_floor": "Gale of Forgetting: Difficulty 4",
+  "battle_num": 4,
+  "has_data": true,
+  "all_floor_detail": [
+    {
+      "name": "Gale of Forgetting: Difficulty 4Starward Mode",
+      "star_num": "0",
+      "node_1": {
+        "challenge_time": {
+          "year": 2026,
+          "month": 6,
+          "day": 8,
+          "hour": 16,
+          "minute": 37
+        },
+        "avatars": [
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1301,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/426b6a8c84d009713b13b2c224c21666.png",
+            "rarity": 4,
+            "element": "fire",
+            "rank": 6
+          }
+        ],
+        "buff": {
+          "id": 3031341,
+          "name_mi18n": "Bold Leader",
+          "desc_mi18n": "The DMG dealt by the character in position 1 in the lineup increases by 60%. For every 4 Skill Points consumed, 1 Skill Point is recovered.",
+          "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/3870e661b3b2c939aa19780e075b8960.png"
+        },
+        "score": "3586",
+        "boss_defeated": true
+      },
+      "node_2": {
+        "challenge_time": {
+          "year": 2026,
+          "month": 6,
+          "day": 8,
+          "hour": 16,
+          "minute": 44
+        },
+        "avatars": [
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1301,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/426b6a8c84d009713b13b2c224c21666.png",
+            "rarity": 4,
+            "element": "fire",
+            "rank": 6
+          }
+        ],
+        "buff": {
+          "id": 3031341,
+          "name_mi18n": "Bold Leader",
+          "desc_mi18n": "The DMG dealt by the character in position 1 in the lineup increases by 60%. For every 4 Skill Points consumed, 1 Skill Point is recovered.",
+          "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/3870e661b3b2c939aa19780e075b8960.png"
+        },
+        "score": "1003",
+        "boss_defeated": false
+      },
+      "maze_id": 30184,
+      "is_fast": false,
+      "last_update_time": {
+        "year": 2026,
+        "month": 6,
+        "day": 8,
+        "hour": 16,
+        "minute": 44
+      },
+      "node_3": null,
+      "extra_star_num": "0",
+      "is_tierce": true
+    },
+    {
+      "name": "Gale of Forgetting: Difficulty 4Regular Mode",
+      "star_num": "0",
+      "node_1": {
+        "challenge_time": {
+          "year": 2026,
+          "month": 6,
+          "day": 8,
+          "hour": 16,
+          "minute": 4
+        },
+        "avatars": [
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1301,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/426b6a8c84d009713b13b2c224c21666.png",
+            "rarity": 4,
+            "element": "fire",
+            "rank": 6
+          }
+        ],
+        "buff": {
+          "id": 3031341,
+          "name_mi18n": "Bold Leader",
+          "desc_mi18n": "The DMG dealt by the character in position 1 in the lineup increases by 60%. For every 4 Skill Points consumed, 1 Skill Point is recovered.",
+          "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/3870e661b3b2c939aa19780e075b8960.png"
+        },
+        "score": "3585",
+        "boss_defeated": true
+      },
+      "node_2": {
+        "challenge_time": {
+          "year": 2026,
+          "month": 6,
+          "day": 8,
+          "hour": 16,
+          "minute": 7
+        },
+        "avatars": [
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1301,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/426b6a8c84d009713b13b2c224c21666.png",
+            "rarity": 4,
+            "element": "fire",
+            "rank": 6
+          }
+        ],
+        "buff": {
+          "id": 3031341,
+          "name_mi18n": "Bold Leader",
+          "desc_mi18n": "The DMG dealt by the character in position 1 in the lineup increases by 60%. For every 4 Skill Points consumed, 1 Skill Point is recovered.",
+          "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/3870e661b3b2c939aa19780e075b8960.png"
+        },
+        "score": "73",
+        "boss_defeated": false
+      },
+      "maze_id": 30184,
+      "is_fast": false,
+      "last_update_time": {
+        "year": 2026,
+        "month": 6,
+        "day": 8,
+        "hour": 16,
+        "minute": 7
+      },
+      "node_3": null,
+      "extra_star_num": "0",
+      "is_tierce": false
+    },
+    {
+      "name": "Gale of Forgetting: Difficulty 3",
+      "star_num": "3",
+      "node_1": {
+        "challenge_time": {
+          "year": 2026,
+          "month": 6,
+          "day": 8,
+          "hour": 15,
+          "minute": 52
+        },
+        "avatars": [
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1301,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/426b6a8c84d009713b13b2c224c21666.png",
+            "rarity": 4,
+            "element": "fire",
+            "rank": 6
+          }
+        ],
+        "buff": {
+          "id": 3031341,
+          "name_mi18n": "Bold Leader",
+          "desc_mi18n": "The DMG dealt by the character in position 1 in the lineup increases by 60%. For every 4 Skill Points consumed, 1 Skill Point is recovered.",
+          "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/3870e661b3b2c939aa19780e075b8960.png"
+        },
+        "score": "3793",
+        "boss_defeated": true
+      },
+      "node_2": {
+        "challenge_time": {
+          "year": 2026,
+          "month": 6,
+          "day": 8,
+          "hour": 15,
+          "minute": 56
+        },
+        "avatars": [
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1301,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/426b6a8c84d009713b13b2c224c21666.png",
+            "rarity": 4,
+            "element": "fire",
+            "rank": 6
+          }
+        ],
+        "buff": {
+          "id": 3031341,
+          "name_mi18n": "Bold Leader",
+          "desc_mi18n": "The DMG dealt by the character in position 1 in the lineup increases by 60%. For every 4 Skill Points consumed, 1 Skill Point is recovered.",
+          "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/3870e661b3b2c939aa19780e075b8960.png"
+        },
+        "score": "3629",
+        "boss_defeated": true
+      },
+      "maze_id": 30183,
+      "is_fast": false,
+      "last_update_time": {
+        "year": 2026,
+        "month": 6,
+        "day": 8,
+        "hour": 15,
+        "minute": 56
+      },
+      "node_3": null,
+      "extra_star_num": "0",
+      "is_tierce": false
+    },
+    {
+      "name": "Gale of Forgetting: Difficulty 2",
+      "star_num": "3",
+      "node_1": {
+        "challenge_time": null,
+        "avatars": [],
+        "buff": null,
+        "score": "0",
+        "boss_defeated": false
+      },
+      "node_2": {
+        "challenge_time": null,
+        "avatars": [],
+        "buff": null,
+        "score": "0",
+        "boss_defeated": false
+      },
+      "maze_id": 30182,
+      "is_fast": true,
+      "last_update_time": {
+        "year": 2026,
+        "month": 6,
+        "day": 8,
+        "hour": 15,
+        "minute": 56
+      },
+      "node_3": null,
+      "extra_star_num": "0",
+      "is_tierce": false
+    },
+    {
+      "name": "Gale of Forgetting: Difficulty 1",
+      "star_num": "3",
+      "node_1": {
+        "challenge_time": null,
+        "avatars": [],
+        "buff": null,
+        "score": "0",
+        "boss_defeated": false
+      },
+      "node_2": {
+        "challenge_time": null,
+        "avatars": [],
+        "buff": null,
+        "score": "0",
+        "boss_defeated": false
+      },
+      "maze_id": 30181,
+      "is_fast": true,
+      "last_update_time": {
+        "year": 2026,
+        "month": 6,
+        "day": 8,
+        "hour": 15,
+        "minute": 56
+      },
+      "node_3": null,
+      "extra_star_num": "0",
+      "is_tierce": false
+    }
+  ],
+  "max_floor_id": 30184,
+  "extra_star_num": 0
+}

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/TestData/Hsr/As_TestData_6.json
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/TestData/Hsr/As_TestData_6.json
@@ -1,0 +1,540 @@
+﻿{
+  "groups": [
+    {
+      "schedule_id": 3018,
+      "begin_time": {
+        "year": 2026,
+        "month": 6,
+        "day": 8,
+        "hour": 4,
+        "minute": 0
+      },
+      "end_time": {
+        "year": 2026,
+        "month": 7,
+        "day": 20,
+        "hour": 4,
+        "minute": 0
+      },
+      "status": "New",
+      "name_mi18n": "Gale of Forgetting",
+      "upper_boss": {
+        "id": 406401204,
+        "name_mi18n": "Arbiter of the Lost Abyss",
+        "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u0a0ae/dcda8f05c05abb87ea74737334d937b5.png"
+      },
+      "lower_boss": {
+        "id": 100401404,
+        "name_mi18n": "Annihilator of Desolation Mistral",
+        "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u0a0ae/50a52a7175589ddcc09b2640b5774f7f.png"
+      },
+      "tierce_boss": {
+        "id": 403401304,
+        "name_mi18n": "Flame Reaver of Doomsday Led Astray",
+        "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u0a0ae/f56b520a4f35f96c07127231a3bd0548.png"
+      }
+    },
+    {
+      "schedule_id": 3017,
+      "begin_time": {
+        "year": 2026,
+        "month": 4,
+        "day": 27,
+        "hour": 4,
+        "minute": 0
+      },
+      "end_time": {
+        "year": 2026,
+        "month": 6,
+        "day": 8,
+        "hour": 4,
+        "minute": 0
+      },
+      "status": "End",
+      "name_mi18n": "Idol of the Locusts",
+      "upper_boss": {
+        "id": 501401404,
+        "name_mi18n": "Super Idol: Center of Attention",
+        "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u0a0ae/eb458e94ee9f053173327981bbebdd4c.png"
+      },
+      "lower_boss": {
+        "id": 802501104,
+        "name_mi18n": "Sky-Shrouding Stardevourer Swarm",
+        "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u0a0ae/f2e2fd5880642f27bf25b6a71d975ce1.png"
+      },
+      "tierce_boss": null
+    }
+  ],
+  "star_num": 12,
+  "max_floor": "Gale of Forgetting: Difficulty 4",
+  "battle_num": 4,
+  "has_data": true,
+  "all_floor_detail": [
+    {
+      "name": "Gale of Forgetting: Difficulty 4Starward Mode",
+      "star_num": "3",
+      "node_1": {
+        "challenge_time": {
+          "year": 2026,
+          "month": 6,
+          "day": 8,
+          "hour": 16,
+          "minute": 37
+        },
+        "avatars": [
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1301,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/426b6a8c84d009713b13b2c224c21666.png",
+            "rarity": 4,
+            "element": "fire",
+            "rank": 6
+          }
+        ],
+        "buff": {
+          "id": 3031341,
+          "name_mi18n": "Bold Leader",
+          "desc_mi18n": "The DMG dealt by the character in position 1 in the lineup increases by 60%. For every 4 Skill Points consumed, 1 Skill Point is recovered.",
+          "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/3870e661b3b2c939aa19780e075b8960.png"
+        },
+        "score": "3586",
+        "boss_defeated": true
+      },
+      "node_2": {
+        "challenge_time": {
+          "year": 2026,
+          "month": 6,
+          "day": 8,
+          "hour": 16,
+          "minute": 44
+        },
+        "avatars": [
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1301,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/426b6a8c84d009713b13b2c224c21666.png",
+            "rarity": 4,
+            "element": "fire",
+            "rank": 6
+          }
+        ],
+        "buff": {
+          "id": 3031341,
+          "name_mi18n": "Bold Leader",
+          "desc_mi18n": "The DMG dealt by the character in position 1 in the lineup increases by 60%. For every 4 Skill Points consumed, 1 Skill Point is recovered.",
+          "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/3870e661b3b2c939aa19780e075b8960.png"
+        },
+        "score": "3586",
+        "boss_defeated": true
+      },
+      "maze_id": 30184,
+      "is_fast": false,
+      "last_update_time": {
+        "year": 2026,
+        "month": 6,
+        "day": 8,
+        "hour": 16,
+        "minute": 44
+      },
+      "node_3": {
+        "challenge_time": {
+          "year": 2026,
+          "month": 6,
+          "day": 8,
+          "hour": 16,
+          "minute": 44
+        },
+        "avatars": [
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1301,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/426b6a8c84d009713b13b2c224c21666.png",
+            "rarity": 4,
+            "element": "fire",
+            "rank": 6
+          }
+        ],
+        "buff": {
+          "id": 3031341,
+          "name_mi18n": "Bold Leader",
+          "desc_mi18n": "The DMG dealt by the character in position 1 in the lineup increases by 60%. For every 4 Skill Points consumed, 1 Skill Point is recovered.",
+          "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/3870e661b3b2c939aa19780e075b8960.png"
+        },
+        "score": "3586",
+        "boss_defeated": true
+      },
+      "extra_star_num": "1",
+      "is_tierce": true
+    },
+    {
+      "name": "Gale of Forgetting: Difficulty 4Regular Mode",
+      "star_num": "0",
+      "node_1": {
+        "challenge_time": {
+          "year": 2026,
+          "month": 6,
+          "day": 8,
+          "hour": 16,
+          "minute": 4
+        },
+        "avatars": [
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1301,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/426b6a8c84d009713b13b2c224c21666.png",
+            "rarity": 4,
+            "element": "fire",
+            "rank": 6
+          }
+        ],
+        "buff": {
+          "id": 3031341,
+          "name_mi18n": "Bold Leader",
+          "desc_mi18n": "The DMG dealt by the character in position 1 in the lineup increases by 60%. For every 4 Skill Points consumed, 1 Skill Point is recovered.",
+          "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/3870e661b3b2c939aa19780e075b8960.png"
+        },
+        "score": "3585",
+        "boss_defeated": true
+      },
+      "node_2": {
+        "challenge_time": {
+          "year": 2026,
+          "month": 6,
+          "day": 8,
+          "hour": 16,
+          "minute": 7
+        },
+        "avatars": [
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1301,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/426b6a8c84d009713b13b2c224c21666.png",
+            "rarity": 4,
+            "element": "fire",
+            "rank": 6
+          }
+        ],
+        "buff": {
+          "id": 3031341,
+          "name_mi18n": "Bold Leader",
+          "desc_mi18n": "The DMG dealt by the character in position 1 in the lineup increases by 60%. For every 4 Skill Points consumed, 1 Skill Point is recovered.",
+          "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/3870e661b3b2c939aa19780e075b8960.png"
+        },
+        "score": "73",
+        "boss_defeated": false
+      },
+      "maze_id": 30184,
+      "is_fast": false,
+      "last_update_time": {
+        "year": 2026,
+        "month": 6,
+        "day": 8,
+        "hour": 16,
+        "minute": 7
+      },
+      "node_3": null,
+      "extra_star_num": "0",
+      "is_tierce": false
+    },
+    {
+      "name": "Gale of Forgetting: Difficulty 3",
+      "star_num": "3",
+      "node_1": {
+        "challenge_time": {
+          "year": 2026,
+          "month": 6,
+          "day": 8,
+          "hour": 15,
+          "minute": 52
+        },
+        "avatars": [
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1301,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/426b6a8c84d009713b13b2c224c21666.png",
+            "rarity": 4,
+            "element": "fire",
+            "rank": 6
+          }
+        ],
+        "buff": {
+          "id": 3031341,
+          "name_mi18n": "Bold Leader",
+          "desc_mi18n": "The DMG dealt by the character in position 1 in the lineup increases by 60%. For every 4 Skill Points consumed, 1 Skill Point is recovered.",
+          "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/3870e661b3b2c939aa19780e075b8960.png"
+        },
+        "score": "3793",
+        "boss_defeated": true
+      },
+      "node_2": {
+        "challenge_time": {
+          "year": 2026,
+          "month": 6,
+          "day": 8,
+          "hour": 15,
+          "minute": 56
+        },
+        "avatars": [
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1301,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/426b6a8c84d009713b13b2c224c21666.png",
+            "rarity": 4,
+            "element": "fire",
+            "rank": 6
+          }
+        ],
+        "buff": {
+          "id": 3031341,
+          "name_mi18n": "Bold Leader",
+          "desc_mi18n": "The DMG dealt by the character in position 1 in the lineup increases by 60%. For every 4 Skill Points consumed, 1 Skill Point is recovered.",
+          "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/3870e661b3b2c939aa19780e075b8960.png"
+        },
+        "score": "3629",
+        "boss_defeated": true
+      },
+      "maze_id": 30183,
+      "is_fast": false,
+      "last_update_time": {
+        "year": 2026,
+        "month": 6,
+        "day": 8,
+        "hour": 15,
+        "minute": 56
+      },
+      "node_3": null,
+      "extra_star_num": "0",
+      "is_tierce": false
+    },
+    {
+      "name": "Gale of Forgetting: Difficulty 2",
+      "star_num": "3",
+      "node_1": {
+        "challenge_time": null,
+        "avatars": [],
+        "buff": null,
+        "score": "0",
+        "boss_defeated": false
+      },
+      "node_2": {
+        "challenge_time": null,
+        "avatars": [],
+        "buff": null,
+        "score": "0",
+        "boss_defeated": false
+      },
+      "maze_id": 30182,
+      "is_fast": true,
+      "last_update_time": {
+        "year": 2026,
+        "month": 6,
+        "day": 8,
+        "hour": 15,
+        "minute": 56
+      },
+      "node_3": null,
+      "extra_star_num": "0",
+      "is_tierce": false
+    },
+    {
+      "name": "Gale of Forgetting: Difficulty 1",
+      "star_num": "3",
+      "node_1": {
+        "challenge_time": null,
+        "avatars": [],
+        "buff": null,
+        "score": "0",
+        "boss_defeated": false
+      },
+      "node_2": {
+        "challenge_time": null,
+        "avatars": [],
+        "buff": null,
+        "score": "0",
+        "boss_defeated": false
+      },
+      "maze_id": 30181,
+      "is_fast": true,
+      "last_update_time": {
+        "year": 2026,
+        "month": 6,
+        "day": 8,
+        "hour": 15,
+        "minute": 56
+      },
+      "node_3": null,
+      "extra_star_num": "0",
+      "is_tierce": false
+    }
+  ],
+  "max_floor_id": 30184,
+  "extra_star_num": 1
+}

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/TestData/Hsr/Pf_TestData_5.json
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/TestData/Hsr/Pf_TestData_5.json
@@ -1,0 +1,388 @@
+﻿{
+  "groups": [
+    {
+      "schedule_id": 2016,
+      "begin_time": {
+        "year": 2025,
+        "month": 7,
+        "day": 21,
+        "hour": 4,
+        "minute": 0
+      },
+      "end_time": {
+        "year": 2025,
+        "month": 9,
+        "day": 1,
+        "hour": 4,
+        "minute": 0
+      },
+      "status": "New",
+      "name_mi18n": "Three Act Structure",
+      "upper_boss": null,
+      "lower_boss": null,
+      "tierce_boss": null
+    },
+    {
+      "schedule_id": 2015,
+      "begin_time": {
+        "year": 2025,
+        "month": 6,
+        "day": 9,
+        "hour": 4,
+        "minute": 0
+      },
+      "end_time": {
+        "year": 2025,
+        "month": 7,
+        "day": 21,
+        "hour": 4,
+        "minute": 0
+      },
+      "status": "End",
+      "name_mi18n": "Narrative Analysis",
+      "upper_boss": null,
+      "lower_boss": null
+    }
+  ],
+  "star_num": 12,
+  "max_floor": "Three Act Structure (IV)",
+  "battle_num": 9,
+  "has_data": true,
+  "all_floor_detail": [
+    {
+      "name": "Three Act Structure (IV)",
+      "round_num": 8,
+      "star_num": 3,
+      "extra_star_num": 1,
+      "node_1": {
+        "challenge_time": {
+          "year": 2025,
+          "month": 7,
+          "day": 21,
+          "hour": 22,
+          "minute": 27
+        },
+        "avatars": [
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1301,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/426b6a8c84d009713b13b2c224c21666.png",
+            "rarity": 4,
+            "element": "fire",
+            "rank": 6
+          }
+        ],
+        "buff": {
+          "id": 3031341,
+          "name_mi18n": "Intertextuality",
+          "desc_mi18n": "During Surging Grit, Skill DMG dealt by ally targets increases by 50%. When attacking targets with the special Wind Shear \"Echo Enigma,\" each stack of \"Echo Enigma\" additionally increases Skill DMG by 10%.",
+          "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/063aa8a893ae68c5bd0be78f86d17f77.png",
+          "simple_desc_mi18m": "Every enemy target hit with ally targets' Skills additionally accumulates 3 Grit Value for allies."
+        },
+        "score": "25360"
+      },
+      "node_2": {
+        "challenge_time": {
+          "year": 2025,
+          "month": 7,
+          "day": 21,
+          "hour": 22,
+          "minute": 27
+        },
+        "avatars": [
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1301,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/426b6a8c84d009713b13b2c224c21666.png",
+            "rarity": 4,
+            "element": "fire",
+            "rank": 6
+          }
+        ],
+        "buff": {
+          "id": 3031341,
+          "name_mi18n": "Intertextuality",
+          "desc_mi18n": "During Surging Grit, Skill DMG dealt by ally targets increases by 50%. When attacking targets with the special Wind Shear \"Echo Enigma,\" each stack of \"Echo Enigma\" additionally increases Skill DMG by 10%.",
+          "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/063aa8a893ae68c5bd0be78f86d17f77.png",
+          "simple_desc_mi18m": "Every enemy target hit with ally targets' Skills additionally accumulates 3 Grit Value for allies."
+        },
+        "score": "27000"
+      },
+      "node_3": {
+        "challenge_time": {
+          "year": 2025,
+          "month": 7,
+          "day": 21,
+          "hour": 22,
+          "minute": 27
+        },
+        "avatars": [
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1301,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/426b6a8c84d009713b13b2c224c21666.png",
+            "rarity": 4,
+            "element": "fire",
+            "rank": 6
+          }
+        ],
+        "buff": {
+          "id": 3031341,
+          "name_mi18n": "Intertextuality",
+          "desc_mi18n": "During Surging Grit, Skill DMG dealt by ally targets increases by 50%. When attacking targets with the special Wind Shear \"Echo Enigma,\" each stack of \"Echo Enigma\" additionally increases Skill DMG by 10%.",
+          "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/063aa8a893ae68c5bd0be78f86d17f77.png",
+          "simple_desc_mi18m": "Every enemy target hit with ally targets' Skills additionally accumulates 3 Grit Value for allies."
+        },
+        "score": "27000"
+      },
+      "maze_id": 20164,
+      "is_fast": false,
+      "is_tierce": true
+    },
+    {
+      "name": "Three Act Structure (III)",
+      "round_num": 5,
+      "star_num": 3,
+      "node_1": {
+        "challenge_time": {
+          "year": 2025,
+          "month": 7,
+          "day": 21,
+          "hour": 8,
+          "minute": 53
+        },
+        "avatars": [
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1301,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/426b6a8c84d009713b13b2c224c21666.png",
+            "rarity": 4,
+            "element": "fire",
+            "rank": 6
+          }
+        ],
+        "buff": {
+          "id": 3031341,
+          "name_mi18n": "Intertextuality",
+          "desc_mi18n": "During Surging Grit, Skill DMG dealt by ally targets increases by 50%. When attacking targets with the special Wind Shear \"Echo Enigma,\" each stack of \"Echo Enigma\" additionally increases Skill DMG by 10%.",
+          "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/063aa8a893ae68c5bd0be78f86d17f77.png",
+          "simple_desc_mi18m": "Every enemy target hit with ally targets' Skills additionally accumulates 3 Grit Value for allies."
+        },
+        "score": "40000"
+      },
+      "node_2": {
+        "challenge_time": {
+          "year": 2025,
+          "month": 7,
+          "day": 21,
+          "hour": 8,
+          "minute": 53
+        },
+        "avatars": [
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1301,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/426b6a8c84d009713b13b2c224c21666.png",
+            "rarity": 4,
+            "element": "fire",
+            "rank": 6
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          }
+        ],
+        "buff": {
+          "id": 3031341,
+          "name_mi18n": "Intertextuality",
+          "desc_mi18n": "During Surging Grit, Skill DMG dealt by ally targets increases by 50%. When attacking targets with the special Wind Shear \"Echo Enigma,\" each stack of \"Echo Enigma\" additionally increases Skill DMG by 10%.",
+          "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/063aa8a893ae68c5bd0be78f86d17f77.png",
+          "simple_desc_mi18m": "Every enemy target hit with ally targets' Skills additionally accumulates 3 Grit Value for allies."
+        },
+        "score": "26800"
+      },
+      "maze_id": 20163,
+      "is_fast": false
+    },
+    {
+      "name": "Three Act Structure (II)",
+      "round_num": 0,
+      "star_num": 3,
+      "node_1": {
+        "challenge_time": {
+          "year": 2025,
+          "month": 7,
+          "day": 21,
+          "hour": 8,
+          "minute": 53
+        },
+        "avatars": [],
+        "buff": null,
+        "score": "0"
+      },
+      "node_2": {
+        "challenge_time": {
+          "year": 2025,
+          "month": 7,
+          "day": 21,
+          "hour": 8,
+          "minute": 53
+        },
+        "avatars": [],
+        "buff": null,
+        "score": "0"
+      },
+      "maze_id": 20162,
+      "is_fast": true
+    },
+    {
+      "name": "Three Act Structure (I)",
+      "round_num": 0,
+      "star_num": 3,
+      "node_1": {
+        "challenge_time": {
+          "year": 2025,
+          "month": 7,
+          "day": 21,
+          "hour": 8,
+          "minute": 53
+        },
+        "avatars": [],
+        "buff": null,
+        "score": "0"
+      },
+      "node_2": {
+        "challenge_time": {
+          "year": 2025,
+          "month": 7,
+          "day": 21,
+          "hour": 8,
+          "minute": 53
+        },
+        "avatars": [],
+        "buff": null,
+        "score": "0"
+      },
+      "maze_id": 20161,
+      "is_fast": true
+    }
+  ],
+  "max_floor_id": 20164,
+  "extra_star_num": 1
+}

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/TestData/Hsr/Pf_TestData_6.json
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/TestData/Hsr/Pf_TestData_6.json
@@ -1,0 +1,338 @@
+﻿{
+  "groups": [
+    {
+      "schedule_id": 2016,
+      "begin_time": {
+        "year": 2025,
+        "month": 7,
+        "day": 21,
+        "hour": 4,
+        "minute": 0
+      },
+      "end_time": {
+        "year": 2025,
+        "month": 9,
+        "day": 1,
+        "hour": 4,
+        "minute": 0
+      },
+      "status": "New",
+      "name_mi18n": "Three Act Structure",
+      "upper_boss": null,
+      "lower_boss": null,
+      "tierce_boss": null
+    },
+    {
+      "schedule_id": 2015,
+      "begin_time": {
+        "year": 2025,
+        "month": 6,
+        "day": 9,
+        "hour": 4,
+        "minute": 0
+      },
+      "end_time": {
+        "year": 2025,
+        "month": 7,
+        "day": 21,
+        "hour": 4,
+        "minute": 0
+      },
+      "status": "End",
+      "name_mi18n": "Narrative Analysis",
+      "upper_boss": null,
+      "lower_boss": null
+    }
+  ],
+  "star_num": 12,
+  "max_floor": "Three Act Structure (IV)",
+  "battle_num": 9,
+  "has_data": true,
+  "all_floor_detail": [
+    {
+      "name": "Three Act Structure (IV)",
+      "round_num": 8,
+      "star_num": 3,
+      "extra_star_num": 0,
+      "node_1": {
+        "challenge_time": {
+          "year": 2025,
+          "month": 7,
+          "day": 21,
+          "hour": 22,
+          "minute": 27
+        },
+        "avatars": [
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1301,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/426b6a8c84d009713b13b2c224c21666.png",
+            "rarity": 4,
+            "element": "fire",
+            "rank": 6
+          }
+        ],
+        "buff": {
+          "id": 3031341,
+          "name_mi18n": "Intertextuality",
+          "desc_mi18n": "During Surging Grit, Skill DMG dealt by ally targets increases by 50%. When attacking targets with the special Wind Shear \"Echo Enigma,\" each stack of \"Echo Enigma\" additionally increases Skill DMG by 10%.",
+          "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/063aa8a893ae68c5bd0be78f86d17f77.png",
+          "simple_desc_mi18m": "Every enemy target hit with ally targets' Skills additionally accumulates 3 Grit Value for allies."
+        },
+        "score": "25360"
+      },
+      "node_2": {
+        "challenge_time": {
+          "year": 2025,
+          "month": 7,
+          "day": 21,
+          "hour": 22,
+          "minute": 27
+        },
+        "avatars": [
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1301,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/426b6a8c84d009713b13b2c224c21666.png",
+            "rarity": 4,
+            "element": "fire",
+            "rank": 6
+          }
+        ],
+        "buff": {
+          "id": 3031341,
+          "name_mi18n": "Intertextuality",
+          "desc_mi18n": "During Surging Grit, Skill DMG dealt by ally targets increases by 50%. When attacking targets with the special Wind Shear \"Echo Enigma,\" each stack of \"Echo Enigma\" additionally increases Skill DMG by 10%.",
+          "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/063aa8a893ae68c5bd0be78f86d17f77.png",
+          "simple_desc_mi18m": "Every enemy target hit with ally targets' Skills additionally accumulates 3 Grit Value for allies."
+        },
+        "score": "27000"
+      },
+      "node_3": null,
+      "maze_id": 20164,
+      "is_fast": false,
+      "is_tierce": true
+    },
+    {
+      "name": "Three Act Structure (III)",
+      "round_num": 5,
+      "star_num": 3,
+      "node_1": {
+        "challenge_time": {
+          "year": 2025,
+          "month": 7,
+          "day": 21,
+          "hour": 8,
+          "minute": 53
+        },
+        "avatars": [
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1301,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/426b6a8c84d009713b13b2c224c21666.png",
+            "rarity": 4,
+            "element": "fire",
+            "rank": 6
+          }
+        ],
+        "buff": {
+          "id": 3031341,
+          "name_mi18n": "Intertextuality",
+          "desc_mi18n": "During Surging Grit, Skill DMG dealt by ally targets increases by 50%. When attacking targets with the special Wind Shear \"Echo Enigma,\" each stack of \"Echo Enigma\" additionally increases Skill DMG by 10%.",
+          "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/063aa8a893ae68c5bd0be78f86d17f77.png",
+          "simple_desc_mi18m": "Every enemy target hit with ally targets' Skills additionally accumulates 3 Grit Value for allies."
+        },
+        "score": "40000"
+      },
+      "node_2": {
+        "challenge_time": {
+          "year": 2025,
+          "month": 7,
+          "day": 21,
+          "hour": 8,
+          "minute": 53
+        },
+        "avatars": [
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          },
+          {
+            "id": 1301,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/426b6a8c84d009713b13b2c224c21666.png",
+            "rarity": 4,
+            "element": "fire",
+            "rank": 6
+          },
+          {
+            "id": 1308,
+            "level": 80,
+            "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/e0f8a27fe8d3051531b29ada40244bb3.png",
+            "rarity": 5,
+            "element": "lightning",
+            "rank": 0
+          }
+        ],
+        "buff": {
+          "id": 3031341,
+          "name_mi18n": "Intertextuality",
+          "desc_mi18n": "During Surging Grit, Skill DMG dealt by ally targets increases by 50%. When attacking targets with the special Wind Shear \"Echo Enigma,\" each stack of \"Echo Enigma\" additionally increases Skill DMG by 10%.",
+          "icon": "https://act-webstatic.hoyoverse.com/darkmatter/hkrpg/prod_gf_cn/item_icon_u732fd/063aa8a893ae68c5bd0be78f86d17f77.png",
+          "simple_desc_mi18m": "Every enemy target hit with ally targets' Skills additionally accumulates 3 Grit Value for allies."
+        },
+        "score": "26800"
+      },
+      "maze_id": 20163,
+      "is_fast": false
+    },
+    {
+      "name": "Three Act Structure (II)",
+      "round_num": 0,
+      "star_num": 3,
+      "node_1": {
+        "challenge_time": {
+          "year": 2025,
+          "month": 7,
+          "day": 21,
+          "hour": 8,
+          "minute": 53
+        },
+        "avatars": [],
+        "buff": null,
+        "score": "0"
+      },
+      "node_2": {
+        "challenge_time": {
+          "year": 2025,
+          "month": 7,
+          "day": 21,
+          "hour": 8,
+          "minute": 53
+        },
+        "avatars": [],
+        "buff": null,
+        "score": "0"
+      },
+      "maze_id": 20162,
+      "is_fast": true
+    },
+    {
+      "name": "Three Act Structure (I)",
+      "round_num": 0,
+      "star_num": 3,
+      "node_1": {
+        "challenge_time": {
+          "year": 2025,
+          "month": 7,
+          "day": 21,
+          "hour": 8,
+          "minute": 53
+        },
+        "avatars": [],
+        "buff": null,
+        "score": "0"
+      },
+      "node_2": {
+        "challenge_time": {
+          "year": 2025,
+          "month": 7,
+          "day": 21,
+          "hour": 8,
+          "minute": 53
+        },
+        "avatars": [],
+        "buff": null,
+        "score": "0"
+      },
+      "maze_id": 20161,
+      "is_fast": true
+    }
+  ],
+  "max_floor_id": 20164,
+  "extra_star_num": 0
+}

--- a/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrApocalypticShadowCardService.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrApocalypticShadowCardService.cs
@@ -1,5 +1,6 @@
 ﻿#region
 
+using System.Text;
 using Mehrak.Application.Shared.Abstractions;
 using Mehrak.Domain.Image;
 using Mehrak.Domain.Image.Models;
@@ -60,9 +61,22 @@ internal class HsrApocalypticShadowCardService : HsrEndGameCardServiceBase
         ];
     }
 
-    protected override string GetStageText(HsrEndInformation gameModeData, int floorNumber)
+    protected override string GetStageText(HsrEndInformation gameModeData, HsrEndFloorDetail? floorData, int floorNumber)
     {
-        return $"{gameModeData.Groups[0].Name}: Difficulty {floorNumber + 1}";
+        var strBuilder = new StringBuilder();
+        strBuilder.Append($"{gameModeData.Groups[0].Name}: Difficulty {floorNumber + 1}");
+        if (floorNumber == 3)
+        {
+            if (floorData?.IsTierce == true)
+            {
+                strBuilder.Append(" Starward Mode");
+            }
+            else
+            {
+                strBuilder.Append(" Regular Mode");
+            }
+        }
+        return strBuilder.ToString();
     }
 
     protected override void DrawNodeExtras(DrawingCanvas region, HsrEndNodeInformation nodeData)

--- a/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrApocalypticShadowCardService.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrApocalypticShadowCardService.cs
@@ -50,7 +50,11 @@ internal class HsrApocalypticShadowCardService : HsrEndGameCardServiceBase
                 .Select(floorIndex =>
                 {
                     var floorData = gameModeData.AllFloorDetail
-                        .FirstOrDefault(x => x.Name.EndsWith((floorIndex + 1).ToString()));
+                        .Where(x => x.MazeId.ToString().EndsWith((floorIndex + 1).ToString()))
+                        .OrderByDescending(x => x.StarNum + x.ExtraStarNum)
+                        .ThenByDescending(x => x.TotalScore)
+                        .ThenByDescending(x => x.IsTierce)
+                        .FirstOrDefault();
                     return (FloorNumber: floorIndex, Data: floorData);
                 })
         ];

--- a/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrApocalypticShadowCardService.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrApocalypticShadowCardService.cs
@@ -16,6 +16,7 @@ namespace Mehrak.Application.Hsr.EndGame;
 internal class HsrApocalypticShadowCardService : HsrEndGameCardServiceBase
 {
     private Image m_AsBackground = null!;
+    private Image m_BossCheckmark = null!;
 
     public HsrApocalypticShadowCardService(IImageRepository imageRepository,
         ILogger<HsrApocalypticShadowCardService> logger,
@@ -29,6 +30,11 @@ internal class HsrApocalypticShadowCardService : HsrEndGameCardServiceBase
         m_AsBackground = await Image.LoadAsync<Rgba32>(
             await ImageRepository.DownloadFileToStreamAsync(FileNameFormat.Hsr.ASBackgroundName, cancellationToken),
             cancellationToken);
+
+        m_BossCheckmark = await Image.LoadAsync(
+            await ImageRepository.DownloadFileToStreamAsync(FileNameFormat.Hsr.BossCheckName, cancellationToken),
+            cancellationToken);
+        m_BossCheckmark.Mutate(ctx => ctx.Transform(new AffineTransformBuilder().AppendTranslation(new PointF(0, -2))));
     }
 
     protected override Image GetModeBackgroundImage() => m_AsBackground;
@@ -55,21 +61,11 @@ internal class HsrApocalypticShadowCardService : HsrEndGameCardServiceBase
         return $"{gameModeData.Groups[0].Name}: Difficulty {floorNumber + 1}";
     }
 
-    protected override void DrawNode1Extras(DrawingCanvas canvas, int xOffset, int yOffset,
-        HsrEndFloorDetail floorData)
+    protected override void DrawNodeExtras(DrawingCanvas region, HsrEndNodeInformation nodeData)
     {
-        if (floorData.Node1!.BossDefeated)
-            canvas.DrawImage(BossCheckmark, BossCheckmark.Bounds,
-                new RectangleF(xOffset + 650, yOffset + 83, BossCheckmark.Width, BossCheckmark.Height),
-                KnownResamplers.Bicubic);
-    }
-
-    protected override void DrawNode2Extras(DrawingCanvas canvas, int xOffset, int yOffset,
-        HsrEndFloorDetail floorData)
-    {
-        if (floorData.Node2!.BossDefeated)
-            canvas.DrawImage(BossCheckmark, BossCheckmark.Bounds,
-                new RectangleF(xOffset + 650, yOffset + 348, BossCheckmark.Width, BossCheckmark.Height),
+        if (nodeData.BossDefeated)
+            region.DrawImage(m_BossCheckmark, m_BossCheckmark.Bounds,
+                new RectangleF(605, 0, m_BossCheckmark.Width, m_BossCheckmark.Height),
                 KnownResamplers.Bicubic);
     }
 }

--- a/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrEndGameCardServiceBase.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrEndGameCardServiceBase.cs
@@ -366,7 +366,7 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
     private static int GetBlobHeight(HsrEndFloorDetail? data)
     {
         if (data == null || data.IsFast) return 180;
-        if (data.IsTierce && (data.Node1 is not null || data.Node2 is not null || data.Node3 is not null)) return 870;
+        if (data.IsTierce) return 870;
         return 600;
     }
 }

--- a/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrEndGameCardServiceBase.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrEndGameCardServiceBase.cs
@@ -25,7 +25,6 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
     protected Image StarLit = null!;
     protected Image StarUnlit = null!;
     protected Image CycleIcon = null!;
-    protected Image BossCheckmark = null!;
 
     protected HsrEndGameCardServiceBase(
         string cardTypeName,
@@ -53,10 +52,6 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
 
         CycleIcon = await Image.LoadAsync(
             await ImageRepository.DownloadFileToStreamAsync(FileNameFormat.Hsr.HourglassName, cancellationToken),
-            cancellationToken);
-
-        BossCheckmark = await Image.LoadAsync(
-            await ImageRepository.DownloadFileToStreamAsync(FileNameFormat.Hsr.BossCheckName, cancellationToken),
             cancellationToken);
     }
 
@@ -108,7 +103,7 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
 
         var floorDetails = GetFloorDetails(gameModeData);
         var height = 210 + floorDetails.Chunk(2)
-            .Sum(x => x.All(y => y.Data == null || IsSmallBlob(y.Data)) ? 200 : 620);
+            .Sum(x => x.Max(y => GetBlobHeight(y.Data)));
 
         background.Mutate(ctx =>
         {
@@ -179,8 +174,7 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
 
                         if (floorNumber % 2 == 1)
                         {
-                            var leftIsFull = floorNumber - 1 >= 0 && !IsSmallBlob(floorDetails[floorNumber - 1].Data);
-                            yOffset += leftIsFull ? 620 : 200;
+                            yOffset += GetBlobHeight(floorNumber - 1 >= 0 ? floorDetails[floorNumber - 1].Data : null);
                         }
                         continue;
                     }
@@ -196,47 +190,14 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
 
                     canvas.Draw(Pens.Solid(Color.White, 2f), new PathBuilder().AddLine(new PointF(xOffset + 20, yOffset + 65),
                         new PointF(xOffset + 880, yOffset + 65)).Build());
-                    canvas.DrawText(new RichTextOptions(Fonts.Normal)
-                    {
-                        Origin = new PointF(xOffset + 45, yOffset + 85)
-                    }, "Node 1", Brushes.Solid(Color.White), null);
-                    canvas.DrawText(new RichTextOptions(Fonts.Normal)
-                    {
-                        Origin = new PointF(xOffset + 855, yOffset + 85),
-                        HorizontalAlignment = HorizontalAlignment.Right
-                    }, $"Score: {floorData.Node1!.Score}", Brushes.Solid(Color.White), null);
 
-                    DrawNode1Extras(canvas, xOffset, yOffset, floorData);
+                    DrawNodeInformation(canvas, new Point(xOffset + 45, yOffset + 85), "Node 1", floorData.Node1, avatarImages, buffImages, DrawNodeExtras);
 
-                    RosterImageBuilder.Draw(
-                        floorData.Node1!.Avatars.Select(x => avatarImages[x.Id]),
-                        new RosterLayout(MaxSlots: 4),
-                        new Point(xOffset + 55, yOffset + 130),
-                        (point, avatar) => avatar.DrawStyledAvatarImage(canvas, point));
-
-                    canvas.DrawCenteredIcon(buffImages[floorData.Node1.Buff.Id], new PointF(xOffset + 780, yOffset + 220), 55,
-                        20f, Color.Black, Color.White);
                     canvas.Draw(Pens.Solid(Color.White, 2f), new PathBuilder().AddLine(new PointF(xOffset + 40, yOffset + 335),
                         new PointF(xOffset + 860, yOffset + 335)).Build());
-                    canvas.DrawText(new RichTextOptions(Fonts.Normal)
-                    {
-                        Origin = new PointF(xOffset + 45, yOffset + 350)
-                    }, "Node 2", Brushes.Solid(Color.White), null);
-                    canvas.DrawText(new RichTextOptions(Fonts.Normal)
-                    {
-                        Origin = new PointF(xOffset + 855, yOffset + 350),
-                        HorizontalAlignment = HorizontalAlignment.Right
-                    }, $"Score: {floorData.Node2!.Score}", Brushes.Solid(Color.White), null);
 
-                    DrawNode2Extras(canvas, xOffset, yOffset, floorData);
+                    DrawNodeInformation(canvas, new Point(xOffset + 45, yOffset + 350), "Node 2", floorData.Node2, avatarImages, buffImages, DrawNodeExtras);
 
-                    RosterImageBuilder.Draw(
-                        floorData.Node2!.Avatars.Select(x => avatarImages[x.Id]),
-                        new RosterLayout(MaxSlots: 4),
-                        new Point(xOffset + 55, yOffset + 395),
-                        (point, avatar) => avatar.DrawStyledAvatarImage(canvas, point));
-                    canvas.DrawCenteredIcon(buffImages[floorData.Node2.Buff.Id], new PointF(xOffset + 780, yOffset + 485), 55,
-                        20f, Color.Black, Color.White);
                     for (var i = 0; i < 3; i++)
                     {
                         var starImage = i < floorData.StarNum ? StarLit : StarUnlit;
@@ -244,9 +205,10 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
                             new RectangleF(xOffset + 730 + i * 50, yOffset + 5, starImage.Width, starImage.Height),
                             KnownResamplers.Bicubic);
                     }
+
                     canvas.Draw(Pens.Solid(Color.White, 2f), new PathBuilder().AddLine(new PointF(xOffset + 720, yOffset + 10),
                         new PointF(xOffset + 720, yOffset + 55)).Build());
-                    var scoreText = $"Score: {int.Parse(floorData.Node1.Score) + int.Parse(floorData.Node2.Score)}";
+                    var scoreText = $"Score: {int.Parse(floorData.Node1?.Score ?? "0") + int.Parse(floorData.Node2?.Score ?? "0")}";
                     canvas.DrawText(new RichTextOptions(Fonts.Normal)
                     {
                         Origin = new PointF(xOffset + 710, yOffset + 20),
@@ -269,6 +231,51 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
                 );
             });
         });
+    }
+
+    private void DrawNodeInformation(
+        DrawingCanvas canvas,
+        Point point,
+        string nodeName,
+        HsrEndNodeInformation? nodeData,
+        Dictionary<int, HsrAvatar> avatarImages,
+        Dictionary<int, Image<Rgba32>> buffImages,
+        Action<DrawingCanvas, HsrEndNodeInformation> drawExtras
+    )
+    {
+        using var region = canvas.CreateRegion(new Rectangle(point, new Size(810, 250)));
+
+        if (nodeData == null)
+        {
+            region.DrawText(new RichTextOptions(Fonts.Normal)
+            {
+                Origin = new PointF(405, 125),
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center
+            }, "No Clear Record", Brushes.Solid(Color.White), null);
+            return;
+        }
+
+        region.DrawText(new RichTextOptions(Fonts.Normal)
+        {
+            Origin = new PointF(0, 0)
+        }, nodeName, Brushes.Solid(Color.White), null);
+        region.DrawText(new RichTextOptions(Fonts.Normal)
+        {
+            Origin = new PointF(810, 0),
+            HorizontalAlignment = HorizontalAlignment.Right
+        }, $"Score: {nodeData.Score}", Brushes.Solid(Color.White), null);
+
+        drawExtras(region, nodeData);
+
+        RosterImageBuilder.Draw(
+            nodeData.Avatars.Select(x => avatarImages[x.Id]),
+            new RosterLayout(MaxSlots: 4),
+            new Point(10, 45),
+            (point, avatar) => avatar.DrawStyledAvatarImage(region, point));
+
+        region.DrawCenteredIcon(buffImages[nodeData.Buff.Id], new PointF(735, 135), 55,
+            20f, Color.Black, Color.White);
     }
 
     private void DrawHeader(DrawingCanvas canvas, HsrEndInformation gameModeData,
@@ -322,17 +329,19 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
 
     protected abstract string GetModeString();
 
-    protected virtual void DrawNode1Extras(DrawingCanvas canvas, int xOffset, int yOffset,
-        HsrEndFloorDetail floorData)
-    { }
-
-    protected virtual void DrawNode2Extras(DrawingCanvas canvas, int xOffset, int yOffset,
-        HsrEndFloorDetail floorData)
+    protected virtual void DrawNodeExtras(DrawingCanvas region, HsrEndNodeInformation nodeData)
     { }
 
     protected virtual void DrawScoreExtras(DrawingCanvas canvas, int xOffset, int yOffset,
         string scoreText, HsrEndFloorDetail floorData, HsrEndInformation gameModeData)
     { }
+
+    private static int GetBlobHeight(HsrEndFloorDetail? data)
+    {
+        if (data == null || data.IsFast) return 200;
+        if (data.IsTierce && (data.Node1 is not null || data.Node2 is not null || data.Node3 is not null)) return 920;
+        return 620;
+    }
 
     private static bool IsSmallBlob(HsrEndFloorDetail? data)
     {

--- a/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrEndGameCardServiceBase.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrEndGameCardServiceBase.cs
@@ -24,6 +24,7 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
 {
     protected Image StarLit = null!;
     protected Image StarUnlit = null!;
+    protected Image ExtraStar = null!;
     protected Image CycleIcon = null!;
 
     protected HsrEndGameCardServiceBase(
@@ -52,6 +53,10 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
 
         CycleIcon = await Image.LoadAsync(
             await ImageRepository.DownloadFileToStreamAsync(FileNameFormat.Hsr.HourglassName, cancellationToken),
+            cancellationToken);
+
+        ExtraStar = await Image.LoadAsync(
+            await ImageRepository.DownloadFileToStreamAsync(FileNameFormat.Hsr.ExtraStarName, cancellationToken),
             cancellationToken);
     }
 
@@ -171,6 +176,7 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
                     var extraRoom = blobHeight - contentEndY;
                     var separator2Y = extraRoom > 0 && !floorData.IsTierce ? blobHeight / 2 : 335;
                     var separator3Y = 605;
+                    var starShift = floorData.ExtraStarNum > 0 ? floorData.ExtraStarNum * 50 : 0;
 
                     var node1Y = 65 + Math.Max(0, (separator2Y - 65 - 250) / 2);
 
@@ -182,40 +188,57 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
                     canvas.Draw(Pens.Solid(Color.White, 2f), new PathBuilder().AddLine(new PointF(xOffset + 20, yOffset + 65),
                         new PointF(xOffset + 880, yOffset + 65)).Build());
 
-                    DrawNodeInformation(canvas, new Point(xOffset + 45, yOffset + node1Y), "Node 1", floorData.Node1, avatarImages, buffImages, DrawNodeExtras);
+                    DrawNodeInformation(canvas, new Point(xOffset + 45, yOffset + node1Y), "Node 1", floorData.Node1,
+                        avatarImages, buffImages, DrawNodeExtras);
 
                     canvas.Draw(Pens.Solid(Color.White, 2f), new PathBuilder().AddLine(new PointF(xOffset + 40, yOffset + separator2Y),
                         new PointF(xOffset + 860, yOffset + separator2Y)).Build());
 
-                    DrawNodeInformation(canvas, new Point(xOffset + 45, yOffset + node2Y), "Node 2", floorData.Node2, avatarImages, buffImages, DrawNodeExtras);
+                    DrawNodeInformation(canvas, new Point(xOffset + 45, yOffset + node2Y), "Node 2", floorData.Node2,
+                        avatarImages, buffImages, DrawNodeExtras);
 
                     if (floorData.IsTierce)
                     {
                         canvas.Draw(Pens.Solid(Color.White, 2f), new PathBuilder().AddLine(new PointF(xOffset + 40, yOffset + separator3Y),
                             new PointF(xOffset + 860, yOffset + separator3Y)).Build());
 
-                        DrawNodeInformation(canvas, new Point(xOffset + 45, yOffset + node3Y), "Node 3", floorData.Node3, avatarImages, buffImages, DrawNodeExtras);
+                        DrawNodeInformation(canvas, new Point(xOffset + 45, yOffset + node3Y), "Node 3", floorData.Node3,
+                            avatarImages, buffImages, DrawNodeExtras);
                     }
 
-                    for (var i = 0; i < 3; i++)
+                    var starX = xOffset + 830;
+
+                    if (floorData.ExtraStarNum > 0)
+                    {
+                        for (var i = 0; i < floorData.ExtraStarNum; i++)
+                        {
+                            canvas.DrawImage(ExtraStar, ExtraStar.Bounds,
+                                new RectangleF(starX, yOffset + 5, ExtraStar.Width, ExtraStar.Height),
+                                KnownResamplers.Bicubic);
+                            starX -= 50;
+                        }
+                    }
+
+                    for (var i = 2; i >= 0; i--)
                     {
                         var starImage = i < floorData.StarNum ? StarLit : StarUnlit;
                         canvas.DrawImage(starImage, starImage.Bounds,
-                            new RectangleF(xOffset + 730 + i * 50, yOffset + 5, starImage.Width, starImage.Height),
+                            new RectangleF(starX, yOffset + 5, starImage.Width, starImage.Height),
                             KnownResamplers.Bicubic);
+                        starX -= 50;
                     }
 
-                    canvas.Draw(Pens.Solid(Color.White, 2f), new PathBuilder().AddLine(new PointF(xOffset + 720, yOffset + 10),
-                        new PointF(xOffset + 720, yOffset + 55)).Build());
+                    canvas.Draw(Pens.Solid(Color.White, 2f), new PathBuilder().AddLine(new PointF(xOffset + 720 - starShift, yOffset + 10),
+                        new PointF(xOffset + 720 - starShift, yOffset + 55)).Build());
                     var scoreText = $"Score: {floorData.TotalScore}";
                     canvas.DrawText(new RichTextOptions(Fonts.Normal)
                     {
-                        Origin = new PointF(xOffset + 710, yOffset + 34),
+                        Origin = new PointF(xOffset + 710 - starShift, yOffset + 34),
                         HorizontalAlignment = HorizontalAlignment.Right,
                         VerticalAlignment = VerticalAlignment.Center
                     }, scoreText, Brushes.Solid(Color.White), null);
 
-                    DrawScoreExtras(canvas, xOffset, yOffset, scoreText, floorData, gameModeData);
+                    DrawScoreExtras(canvas, xOffset - starShift, yOffset, scoreText, floorData, gameModeData);
 
                     if (floorNumber % 2 == 1) yOffset += blobHeight + 20;
                 }
@@ -238,8 +261,7 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
         HsrEndNodeInformation? nodeData,
         Dictionary<int, HsrAvatar> avatarImages,
         Dictionary<int, Image<Rgba32>> buffImages,
-        Action<DrawingCanvas, HsrEndNodeInformation> drawExtras
-    )
+        Action<DrawingCanvas, HsrEndNodeInformation> drawExtras)
     {
         using var region = canvas.CreateRegion(new Rectangle(point, new Size(810, 250)));
 
@@ -306,10 +328,18 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
         };
         var bounds = TextMeasurer.MeasureBounds(gameModeData.StarNum.ToString(), textOptions);
         canvas.DrawText(textOptions, gameModeData.StarNum.ToString(), Brushes.Solid(Color.White), null);
-        var starLit = StarLit;
-        canvas.DrawImage(starLit, starLit.Bounds,
-            new RectangleF((int)bounds.Right + 5, 30, starLit.Width, starLit.Height),
+        canvas.DrawImage(StarLit, StarLit.Bounds,
+            new RectangleF((int)bounds.Right + 5, 30, StarLit.Width, StarLit.Height),
             KnownResamplers.Bicubic);
+        if (gameModeData.ExtraStarNum > 0)
+        {
+            textOptions = new(textOptions) { Origin = new Vector2(bounds.Right + StarLit.Width + 10, 80) };
+            bounds = TextMeasurer.MeasureBounds(gameModeData.ExtraStarNum.ToString(), textOptions);
+            canvas.DrawText(textOptions, gameModeData.ExtraStarNum.ToString(), Brushes.Solid(Color.White), null);
+            canvas.DrawImage(ExtraStar, ExtraStar.Bounds,
+                new RectangleF((int)bounds.Right + 5, 30, ExtraStar.Width, ExtraStar.Height),
+                KnownResamplers.Bicubic);
+        }
 
         canvas.DrawText(new RichTextOptions(Fonts.Normal)
         {

--- a/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrEndGameCardServiceBase.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrEndGameCardServiceBase.cs
@@ -178,12 +178,10 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
                     var separator3Y = 605;
                     var starShift = floorData.ExtraStarNum > 0 ? floorData.ExtraStarNum * 50 : 0;
 
-                    var node1Y = 65 + Math.Max(0, (separator2Y - 65 - 250) / 2);
-
+                    var node1Y = Math.Max(85, (65 + separator2Y) / 2 - 125);
                     var section2End = floorData.IsTierce ? separator3Y : blobHeight;
-                    var node2Y = separator2Y + Math.Max(0, (section2End - separator2Y - 250) / 2);
-
-                    var node3Y = separator3Y + Math.Max(15, (blobHeight - separator3Y - 250) / 2);
+                    var node2Y = Math.Max(separator2Y + 15, (separator2Y + section2End) / 2 - 125);
+                    var node3Y = Math.Max(separator3Y + 15, (separator3Y + blobHeight) / 2 - 125);
 
                     canvas.Draw(Pens.Solid(Color.White, 2f), new PathBuilder().AddLine(new PointF(xOffset + 20, yOffset + 65),
                         new PointF(xOffset + 880, yOffset + 65)).Build());
@@ -368,7 +366,7 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
     private static int GetBlobHeight(HsrEndFloorDetail? data)
     {
         if (data == null || data.IsFast) return 180;
-        if (data.IsTierce && (data.Node1 is not null || data.Node2 is not null || data.Node3 is not null)) return 850;
+        if (data.IsTierce && (data.Node1 is not null || data.Node2 is not null || data.Node3 is not null)) return 870;
         return 600;
     }
 }

--- a/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrEndGameCardServiceBase.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrEndGameCardServiceBase.cs
@@ -103,7 +103,8 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
 
         var floorDetails = GetFloorDetails(gameModeData);
         var height = 210 + floorDetails.Chunk(2)
-            .Sum(x => x.Max(y => GetBlobHeight(y.Data)));
+            .Sum(((int FloorNumber, HsrEndFloorDetail? Data)[] x) =>
+                x.Max(((int FloorNumber, HsrEndFloorDetail? Data) y) => GetBlobHeight(y.Data)));
 
         background.Mutate(ctx =>
         {
@@ -208,7 +209,7 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
 
                     canvas.Draw(Pens.Solid(Color.White, 2f), new PathBuilder().AddLine(new PointF(xOffset + 720, yOffset + 10),
                         new PointF(xOffset + 720, yOffset + 55)).Build());
-                    var scoreText = $"Score: {int.Parse(floorData.Node1?.Score ?? "0") + int.Parse(floorData.Node2?.Score ?? "0")}";
+                    var scoreText = $"Score: {floorData.TotalScore}";
                     canvas.DrawText(new RichTextOptions(Fonts.Normal)
                     {
                         Origin = new PointF(xOffset + 710, yOffset + 20),
@@ -339,7 +340,7 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
     private static int GetBlobHeight(HsrEndFloorDetail? data)
     {
         if (data == null || data.IsFast) return 200;
-        if (data.IsTierce && (data.Node1 is not null || data.Node2 is not null || data.Node3 is not null)) return 920;
+        if (data.IsTierce && (data.Node1 is not null || data.Node2 is not null || data.Node3 is not null)) return 870;
         return 620;
     }
 

--- a/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrEndGameCardServiceBase.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrEndGameCardServiceBase.cs
@@ -83,8 +83,8 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
         var gameModeData = context.Data;
 
         var avatarImages = await gameModeData.AllFloorDetail
-            .Where(x => x is { Node1: not null, Node2: not null })
-            .SelectMany(x => x.Node1!.Avatars.Concat(x.Node2!.Avatars))
+            .SelectMany(x =>
+                (x.Node1?.Avatars ?? []).Concat(x.Node2?.Avatars ?? []).Concat(x.Node3?.Avatars ?? []))
             .DistinctBy(x => x.Id).ToAsyncEnumerable()
             .Select(async (x, token) =>
             {
@@ -96,9 +96,8 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
             .ToDictionaryAsync(x => x.AvatarId, x => x, cancellationToken: cancellationToken);
 
         var buffImages = await gameModeData.AllFloorDetail
-            .Where(x => x is { Node1: not null, Node2: not null })
-            .SelectMany(x => new HsrEndBuff[] { x.Node1!.Buff, x.Node2!.Buff })
-            .Where(x => x is not null)
+            .SelectMany(x => new[] { x.Node1?.Buff, x.Node2?.Buff, x.Node3?.Buff })
+            .OfType<HsrEndBuff>()
             .DistinctBy(x => x.Id)
             .ToAsyncEnumerable()
             .ToDictionaryAsync(
@@ -371,10 +370,5 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
         if (data == null || data.IsFast) return 180;
         if (data.IsTierce && (data.Node1 is not null || data.Node2 is not null || data.Node3 is not null)) return 850;
         return 600;
-    }
-
-    private static bool IsSmallBlob(HsrEndFloorDetail? data)
-    {
-        return data == null || data.IsFast;
     }
 }

--- a/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrEndGameCardServiceBase.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrEndGameCardServiceBase.cs
@@ -62,7 +62,7 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
     protected abstract List<(int FloorNumber, HsrEndFloorDetail? Data)> GetFloorDetails(
         HsrEndInformation gameModeData);
 
-    protected abstract string GetStageText(HsrEndInformation gameModeData, int floorNumber);
+    protected abstract string GetStageText(HsrEndInformation gameModeData, HsrEndFloorDetail? floorData, int floorNumber);
 
     protected override Image<Rgba32> CreateBackground()
     {
@@ -102,9 +102,12 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
                 cancellationToken: cancellationToken);
 
         var floorDetails = GetFloorDetails(gameModeData);
-        var height = 210 + floorDetails.Chunk(2)
-            .Sum(((int FloorNumber, HsrEndFloorDetail? Data)[] x) =>
-                x.Max(((int FloorNumber, HsrEndFloorDetail? Data) y) => GetBlobHeight(y.Data)));
+        var pairBlobHeights = Enumerable.Range(0, 2)
+            .Select(pairIndex => Math.Max(
+                GetBlobHeight(floorDetails[pairIndex * 2].Data),
+                GetBlobHeight(floorDetails[pairIndex * 2 + 1].Data)))
+            .ToArray();
+        var height = 250 + pairBlobHeights.Sum();
 
         background.Mutate(ctx =>
         {
@@ -125,45 +128,29 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
                 foreach ((var floorNumber, var floorData) in floorDetails)
                 {
                     var xOffset = floorNumber % 2 * 950 + 50;
+                    var blobHeight = pairBlobHeights[floorNumber / 2];
+                    canvas.DrawRoundedRectangleOverlay(900, blobHeight, new PointF(xOffset, yOffset),
+                        new RoundedRectangleOverlayStyle(OverlayColor, CornerRadius: 15));
+
+                    var stageText = GetStageText(gameModeData, floorData, floorNumber);
+
+                    var bounds = TextMeasurer.MeasureBounds(stageText, new TextOptions(Fonts.Normal));
+                    canvas.DrawText(new RichTextOptions(bounds.Width >= 450 ? Fonts.Small : Fonts.Normal)
+                    {
+                        Origin = new PointF(xOffset + 20, yOffset + 34),
+                        HorizontalAlignment = HorizontalAlignment.Left,
+                        VerticalAlignment = VerticalAlignment.Center,
+                        WrappingLength = 450
+                    }, stageText, Brushes.Solid(Color.White), null);
 
                     if (floorData == null || floorData.IsFast)
                     {
-                        if ((floorNumber % 2 == 0 && floorNumber + 1 < floorDetails.Count &&
-                             !IsSmallBlob(floorDetails[floorNumber + 1].Data)) ||
-                            (floorNumber % 2 == 1 && floorNumber - 1 >= 0 &&
-                             !IsSmallBlob(floorDetails[floorNumber - 1].Data)))
-                        {
-                            canvas.DrawRoundedRectangleOverlay(900, 600, new PointF(xOffset, yOffset),
-                                new RoundedRectangleOverlayStyle(OverlayColor, CornerRadius: 15));
-                            canvas.DrawText(new RichTextOptions(Fonts.Normal)
-                            {
-                                Origin = new PointF(xOffset + 450, yOffset + 280),
-                                HorizontalAlignment = HorizontalAlignment.Center,
-                                VerticalAlignment = VerticalAlignment.Center
-                            }, floorData?.IsFast ?? false ? "Quick Clear" : "No Clear Records", Brushes.Solid(Color.White), null);
-                        }
-                        else
-                        {
-                            canvas.DrawRoundedRectangleOverlay(900, 180, new PointF(xOffset, yOffset),
-                                new RoundedRectangleOverlayStyle(OverlayColor, CornerRadius: 15));
-                            canvas.DrawText(new RichTextOptions(Fonts.Normal)
-                            {
-                                Origin = new PointF(xOffset + 450, yOffset + 110),
-                                HorizontalAlignment = HorizontalAlignment.Center,
-                                VerticalAlignment = VerticalAlignment.Center
-                            }, floorData?.IsFast ?? false ? "Quick Clear" : "No Clear Records", Brushes.Solid(Color.White), null);
-                        }
-
-                        var stageText = GetStageText(gameModeData, floorNumber);
-
                         canvas.DrawText(new RichTextOptions(Fonts.Normal)
                         {
-                            Origin = new PointF(xOffset + 20, yOffset + 20),
-                            HorizontalAlignment = HorizontalAlignment.Left,
-                            VerticalAlignment = VerticalAlignment.Top
-                        },
-                            floorData?.Name ?? stageText,
-                            Brushes.Solid(Color.White), null);
+                            Origin = new PointF(xOffset + 450, yOffset + blobHeight / 2),
+                            HorizontalAlignment = HorizontalAlignment.Center,
+                            VerticalAlignment = VerticalAlignment.Center
+                        }, floorData?.IsFast ?? false ? "Quick Clear" : "No Clear Records", Brushes.Solid(Color.White), null);
 
                         for (var i = 0; i < 3; i++)
                         {
@@ -175,29 +162,40 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
 
                         if (floorNumber % 2 == 1)
                         {
-                            yOffset += GetBlobHeight(floorNumber - 1 >= 0 ? floorDetails[floorNumber - 1].Data : null);
+                            yOffset += blobHeight + 20;
                         }
                         continue;
                     }
 
-                    canvas.DrawRoundedRectangleOverlay(900, 600, new PointF(xOffset, yOffset),
-                        new RoundedRectangleOverlayStyle(OverlayColor, CornerRadius: 15));
-                    canvas.DrawText(new RichTextOptions(Fonts.Normal)
-                    {
-                        Origin = new PointF(xOffset + 20, yOffset + 20),
-                        HorizontalAlignment = HorizontalAlignment.Left,
-                        VerticalAlignment = VerticalAlignment.Top
-                    }, floorData.Name, Brushes.Solid(Color.White), null);
+                    var contentEndY = floorData.IsTierce ? 870 : 600;
+                    var extraRoom = blobHeight - contentEndY;
+                    var separator2Y = extraRoom > 0 && !floorData.IsTierce ? blobHeight / 2 : 335;
+                    var separator3Y = 605;
+
+                    var node1Y = 65 + Math.Max(0, (separator2Y - 65 - 250) / 2);
+
+                    var section2End = floorData.IsTierce ? separator3Y : blobHeight;
+                    var node2Y = separator2Y + Math.Max(0, (section2End - separator2Y - 250) / 2);
+
+                    var node3Y = separator3Y + Math.Max(15, (blobHeight - separator3Y - 250) / 2);
 
                     canvas.Draw(Pens.Solid(Color.White, 2f), new PathBuilder().AddLine(new PointF(xOffset + 20, yOffset + 65),
                         new PointF(xOffset + 880, yOffset + 65)).Build());
 
-                    DrawNodeInformation(canvas, new Point(xOffset + 45, yOffset + 85), "Node 1", floorData.Node1, avatarImages, buffImages, DrawNodeExtras);
+                    DrawNodeInformation(canvas, new Point(xOffset + 45, yOffset + node1Y), "Node 1", floorData.Node1, avatarImages, buffImages, DrawNodeExtras);
 
-                    canvas.Draw(Pens.Solid(Color.White, 2f), new PathBuilder().AddLine(new PointF(xOffset + 40, yOffset + 335),
-                        new PointF(xOffset + 860, yOffset + 335)).Build());
+                    canvas.Draw(Pens.Solid(Color.White, 2f), new PathBuilder().AddLine(new PointF(xOffset + 40, yOffset + separator2Y),
+                        new PointF(xOffset + 860, yOffset + separator2Y)).Build());
 
-                    DrawNodeInformation(canvas, new Point(xOffset + 45, yOffset + 350), "Node 2", floorData.Node2, avatarImages, buffImages, DrawNodeExtras);
+                    DrawNodeInformation(canvas, new Point(xOffset + 45, yOffset + node2Y), "Node 2", floorData.Node2, avatarImages, buffImages, DrawNodeExtras);
+
+                    if (floorData.IsTierce)
+                    {
+                        canvas.Draw(Pens.Solid(Color.White, 2f), new PathBuilder().AddLine(new PointF(xOffset + 40, yOffset + separator3Y),
+                            new PointF(xOffset + 860, yOffset + separator3Y)).Build());
+
+                        DrawNodeInformation(canvas, new Point(xOffset + 45, yOffset + node3Y), "Node 3", floorData.Node3, avatarImages, buffImages, DrawNodeExtras);
+                    }
 
                     for (var i = 0; i < 3; i++)
                     {
@@ -212,15 +210,14 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
                     var scoreText = $"Score: {floorData.TotalScore}";
                     canvas.DrawText(new RichTextOptions(Fonts.Normal)
                     {
-                        Origin = new PointF(xOffset + 710, yOffset + 20),
+                        Origin = new PointF(xOffset + 710, yOffset + 34),
                         HorizontalAlignment = HorizontalAlignment.Right,
-                        VerticalAlignment = VerticalAlignment.Top
-                    }, scoreText,
-                        Brushes.Solid(Color.White), null);
+                        VerticalAlignment = VerticalAlignment.Center
+                    }, scoreText, Brushes.Solid(Color.White), null);
 
                     DrawScoreExtras(canvas, xOffset, yOffset, scoreText, floorData, gameModeData);
 
-                    if (floorNumber % 2 == 1) yOffset += 620;
+                    if (floorNumber % 2 == 1) yOffset += blobHeight + 20;
                 }
                 canvas.DrawAttribution(new RichTextOptions(Fonts.Tiny)
                 {
@@ -246,21 +243,22 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
     {
         using var region = canvas.CreateRegion(new Rectangle(point, new Size(810, 250)));
 
+        region.DrawText(new RichTextOptions(Fonts.Normal)
+        {
+            Origin = new PointF(0, 0)
+        }, nodeName, Brushes.Solid(Color.White), null);
+
         if (nodeData == null)
         {
             region.DrawText(new RichTextOptions(Fonts.Normal)
             {
-                Origin = new PointF(405, 125),
+                Origin = new PointF(400, 125),
                 HorizontalAlignment = HorizontalAlignment.Center,
                 VerticalAlignment = VerticalAlignment.Center
             }, "No Clear Record", Brushes.Solid(Color.White), null);
             return;
         }
 
-        region.DrawText(new RichTextOptions(Fonts.Normal)
-        {
-            Origin = new PointF(0, 0)
-        }, nodeName, Brushes.Solid(Color.White), null);
         region.DrawText(new RichTextOptions(Fonts.Normal)
         {
             Origin = new PointF(810, 0),
@@ -339,9 +337,9 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
 
     private static int GetBlobHeight(HsrEndFloorDetail? data)
     {
-        if (data == null || data.IsFast) return 200;
-        if (data.IsTierce && (data.Node1 is not null || data.Node2 is not null || data.Node3 is not null)) return 870;
-        return 620;
+        if (data == null || data.IsFast) return 180;
+        if (data.IsTierce && (data.Node1 is not null || data.Node2 is not null || data.Node3 is not null)) return 850;
+        return 600;
     }
 
     private static bool IsSmallBlob(HsrEndFloorDetail? data)

--- a/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrEndGameCardServiceBase.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrEndGameCardServiceBase.cs
@@ -139,13 +139,14 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
 
                     var stageText = GetStageText(gameModeData, floorData, floorNumber);
 
+                    var maxTextWidth = floorData?.ExtraStarNum > 0 ? 380 : 450;
                     var bounds = TextMeasurer.MeasureBounds(stageText, new TextOptions(Fonts.Normal));
-                    canvas.DrawText(new RichTextOptions(bounds.Width >= 450 ? Fonts.Small : Fonts.Normal)
+                    canvas.DrawText(new RichTextOptions(bounds.Width >= maxTextWidth ? Fonts.Small : Fonts.Normal)
                     {
                         Origin = new PointF(xOffset + 20, yOffset + 34),
                         HorizontalAlignment = HorizontalAlignment.Left,
                         VerticalAlignment = VerticalAlignment.Center,
-                        WrappingLength = 450
+                        WrappingLength = maxTextWidth
                     }, stageText, Brushes.Solid(Color.White), null);
 
                     if (floorData == null || floorData.IsFast)

--- a/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrPureFictionCardService.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrPureFictionCardService.cs
@@ -52,7 +52,7 @@ internal class HsrPureFictionCardService : HsrEndGameCardServiceBase
         ];
     }
 
-    protected override string GetStageText(HsrEndInformation gameModeData, int floorNumber)
+    protected override string GetStageText(HsrEndInformation gameModeData, HsrEndFloorDetail? floorData, int floorNumber)
     {
         return $"{gameModeData.Groups[0].Name} ({HsrUtility.GetRomanNumeral(floorNumber + 1)})";
     }

--- a/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrPureFictionCardService.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrPureFictionCardService.cs
@@ -47,7 +47,11 @@ internal class HsrPureFictionCardService : HsrEndGameCardServiceBase
                 .Select(floorIndex =>
                 {
                     var floorData = gameModeData.AllFloorDetail
-                        .FirstOrDefault(x => HsrUtility.GetFloorNumber(x.Name) - 1 == floorIndex);
+                        .Where(x => x.MazeId.ToString().EndsWith((floorIndex + 1).ToString()))
+                        .OrderByDescending(x => x.StarNum + x.ExtraStarNum)
+                        .ThenByDescending(x => x.TotalScore)
+                        .ThenByDescending(x => x.IsTierce)
+                        .FirstOrDefault();
                     return (FloorNumber: floorIndex, Data: floorData);
                 })
         ];

--- a/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrPureFictionCardService.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrPureFictionCardService.cs
@@ -1,5 +1,6 @@
 ﻿#region
 
+using System.Text;
 using Mehrak.Application.Shared.Abstractions;
 using Mehrak.Domain.Image;
 using Mehrak.Domain.Image.Models;
@@ -54,7 +55,21 @@ internal class HsrPureFictionCardService : HsrEndGameCardServiceBase
 
     protected override string GetStageText(HsrEndInformation gameModeData, HsrEndFloorDetail? floorData, int floorNumber)
     {
-        return $"{gameModeData.Groups[0].Name} ({HsrUtility.GetRomanNumeral(floorNumber + 1)})";
+        var strBuilder = new StringBuilder();
+
+        strBuilder.Append($"{gameModeData.Groups[0].Name} ({HsrUtility.GetRomanNumeral(floorNumber + 1)})");
+        if (floorNumber == 3)
+        {
+            if (floorData?.IsTierce == true)
+            {
+                strBuilder.Append(" Starward Mode");
+            }
+            else
+            {
+                strBuilder.Append(" Regular Mode");
+            }
+        }
+        return strBuilder.ToString();
     }
 
     protected override void DrawScoreExtras(DrawingCanvas canvas, int xOffset, int yOffset,
@@ -67,7 +82,7 @@ internal class HsrPureFictionCardService : HsrEndGameCardServiceBase
 
         canvas.DrawText(new RichTextOptions(Fonts.Normal)
         {
-            Origin = new PointF(xOffset + 650 - (int)size.Width, yOffset + 20),
+            Origin = new PointF(xOffset + 655 - (int)size.Width, yOffset + 20),
             HorizontalAlignment = HorizontalAlignment.Right,
             VerticalAlignment = VerticalAlignment.Top
         }, floorData.RoundNum.ToString(), Brushes.Solid(Color.White), null);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extra-star count and icons shown in end-game result cards.
  * Stage labels now show “Starward Mode” or “Regular Mode” for the special floor variant.
  * Boss victory checkmark appears on defeated-node entries.
  * Improved support and sorting for three-node challenge floors; total floor scores aggregated.

* **Tests**
  * Expanded test coverage with multiple new game-scenario fixtures and updated deserialization handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->