### PR TITLE
Fix HYL command failing for image/video only posts

### DIFF
--- a/MehrakBot/Common/Mehrak.GameApi/Hoyolab/HylPost.cs
+++ b/MehrakBot/Common/Mehrak.GameApi/Hoyolab/HylPost.cs
@@ -20,6 +20,7 @@ public class HylPostDetail
     [JsonPropertyName("uid")] public required string Uid { get; set; }
     [JsonPropertyName("subject")] public required string Subject { get; set; }
     [JsonPropertyName("created_at")] public long CreatedAt { get; set; }
+    [JsonPropertyName("content")] public required string Content { get; set; }
     [JsonPropertyName("structured_content")] public required string StructuredContent { get; set; }
     [JsonPropertyName("origin_lang")] public required string OriginLang { get; set; }
     [JsonPropertyName("lang")] public required string Lang { get; set; }

--- a/MehrakBot/Services/Bot/Mehrak.Bot.Tests/HylEmbed/HylEmbedServiceTests.cs
+++ b/MehrakBot/Services/Bot/Mehrak.Bot.Tests/HylEmbed/HylEmbedServiceTests.cs
@@ -226,6 +226,83 @@ public class HylEmbedServiceTests
         Assert.That(mediaUrl, Is.EqualTo("https://example.com/cover.jpg"));
     }
 
+    [Test]
+    public async Task ExecuteAsync_ImageOnlyPost_IncludesMediaGallery()
+    {
+        // Arrange
+        var postData = LoadTestPost("hyl_post_5.json");
+        m_MockApiService
+            .Setup(x => x.GetAsync(It.IsAny<HylPostApiContext>()))
+            .ReturnsAsync(Result<HylPost>.Success(postData));
+
+        var interaction = m_DiscordHelper.CreateCommandInteraction(m_TestUserId);
+        var mockContext = new Mock<IBotContext>();
+        var mockDiscordContext = new Mock<IInteractionContext>();
+        mockDiscordContext.SetupGet(x => x.Interaction).Returns(interaction);
+        mockContext.SetupGet(x => x.DiscordContext).Returns(mockDiscordContext.Object);
+        mockContext.Setup(x => x.GetParameter<long>("postId")).Returns(TestPostId);
+        mockContext.Setup(x => x.GetParameter<WikiLocales>("locale")).Returns(TestLocale);
+
+        m_Service.Context = mockContext.Object;
+
+        // Act
+        await m_Service.ExecuteAsync();
+
+        // Assert
+        var response = await m_DiscordHelper.ExtractInteractionResponseDataAsync();
+        Assert.That(response, Does.Contain("Sample Post with image only"));
+        Assert.That(response, Does.Contain("hoyolab.com/article/44470660"));
+
+        using var json = JsonDocument.Parse(response);
+        var components = json.RootElement.GetProperty("components");
+        var innerComponents = components[0].GetProperty("components");
+
+        var mediaGallery = innerComponents.EnumerateArray()
+            .FirstOrDefault(c => c.TryGetProperty("type", out var t) && t.GetInt32() == 12);
+        Assert.That(mediaGallery.ValueKind, Is.EqualTo(JsonValueKind.Object));
+
+        var items = mediaGallery.GetProperty("items");
+        Assert.That(items.GetArrayLength(), Is.EqualTo(1));
+
+        var mediaUrl = items[0].GetProperty("media").GetProperty("url").GetString();
+        Assert.That(mediaUrl, Is.EqualTo("https://example.com/image.jpg"));
+    }
+
+    [Test]
+    public async Task ExecuteAsync_ImageOnlyPost_NullInsertSkipped()
+    {
+        // Arrange
+        var postData = LoadTestPost("hyl_post_5.json");
+        m_MockApiService
+            .Setup(x => x.GetAsync(It.IsAny<HylPostApiContext>()))
+            .ReturnsAsync(Result<HylPost>.Success(postData));
+
+        var interaction = m_DiscordHelper.CreateCommandInteraction(m_TestUserId);
+        var mockContext = new Mock<IBotContext>();
+        var mockDiscordContext = new Mock<IInteractionContext>();
+        mockDiscordContext.SetupGet(x => x.Interaction).Returns(interaction);
+        mockContext.SetupGet(x => x.DiscordContext).Returns(mockDiscordContext.Object);
+        mockContext.Setup(x => x.GetParameter<long>("postId")).Returns(TestPostId);
+        mockContext.Setup(x => x.GetParameter<WikiLocales>("locale")).Returns(TestLocale);
+
+        m_Service.Context = mockContext.Object;
+
+        // Act
+        await m_Service.ExecuteAsync();
+
+        // Assert - title and footer are always added; content JSON has no recognized insert type
+        // so only those 2 text displays should exist (no extra text from inserts)
+        var response = await m_DiscordHelper.ExtractInteractionResponseDataAsync();
+        using var json = JsonDocument.Parse(response);
+        var components = json.RootElement.GetProperty("components");
+        var innerComponents = components[0].GetProperty("components");
+
+        var textDisplays = innerComponents.EnumerateArray()
+            .Where(c => c.TryGetProperty("type", out var t) && t.GetInt32() == 10)
+            .ToList();
+        Assert.That(textDisplays.Count, Is.EqualTo(2));
+    }
+
     #endregion
 
     #region ExecuteAsync - Error Handling Tests

--- a/MehrakBot/Services/Bot/Mehrak.Bot.Tests/TestData/hyl_post_5.json
+++ b/MehrakBot/Services/Bot/Mehrak.Bot.Tests/TestData/hyl_post_5.json
@@ -1,0 +1,33 @@
+{
+  "post": {
+    "game_id": 2,
+    "post_id": "44470660",
+    "f_forum_id": 0,
+    "uid": "1015537",
+    "subject": "Sample Post with image only",
+    "content": "{\"describe\":\"Some to be omitted description text\",\"imgs\":[\"https://example.com/image.jpg\"]}",
+    "structured_content": "",
+    "structured_content_rows": [],
+    "lang": "en-us",
+    "is_audit": false,
+    "is_multi_language": true,
+    "origin_lang": "en-us",
+    "created_at": 1712131630
+  },
+  "image_list": [
+    {
+      "url": "https://example.com/image.jpg",
+      "height": 675,
+      "width": 1200,
+      "format": "JPEG",
+      "size": "160811",
+      "spoiler": false,
+      "tag_info": {
+        "is_long_picture": false
+      },
+      "template_info": null,
+      "image_id": "133963632"
+    }
+  ],
+  "cover_list": []
+}

--- a/MehrakBot/Services/Bot/Mehrak.Bot/HylEmbed/HylEmbedService.cs
+++ b/MehrakBot/Services/Bot/Mehrak.Bot/HylEmbed/HylEmbedService.cs
@@ -62,6 +62,8 @@ internal partial class HylEmbedService : IBotService
         List<HylPostStructuredInsert>? inserts;
         try
         {
+            // structured content is only empty for image/video only posts
+            // in this case, post.content becomes a JSON string with InsertImage/InsertVideo that we can parse to build the embed
             if (string.IsNullOrWhiteSpace(post.Post.StructuredContent))
             {
                 inserts = [new HylPostStructuredInsert { Insert = JsonSerializer.Deserialize<HylPostInsertContent>(post.Post.Content) }];

--- a/MehrakBot/Services/Bot/Mehrak.Bot/HylEmbed/HylEmbedService.cs
+++ b/MehrakBot/Services/Bot/Mehrak.Bot/HylEmbed/HylEmbedService.cs
@@ -62,7 +62,14 @@ internal partial class HylEmbedService : IBotService
         List<HylPostStructuredInsert>? inserts;
         try
         {
-            inserts = JsonSerializer.Deserialize<List<HylPostStructuredInsert>>(post.Post.StructuredContent);
+            if (string.IsNullOrWhiteSpace(post.Post.StructuredContent))
+            {
+                inserts = [new HylPostStructuredInsert { Insert = JsonSerializer.Deserialize<HylPostInsertContent>(post.Post.Content) }];
+            }
+            else
+            {
+                inserts = JsonSerializer.Deserialize<List<HylPostStructuredInsert>>(post.Post.StructuredContent);
+            }
         }
         catch (JsonException e)
         {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved display of image-only posts by implementing enhanced fallback content parsing. Posts containing only images now render correctly, even when standard content formatting is unavailable.

* **Tests**
  * Added test cases validating image-only post rendering and image display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->