### PR TITLE
HSR Endgame app service NRE when processing node images

### DIFF
--- a/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrEndGameApplicationService.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrEndGameApplicationService.cs
@@ -133,11 +133,12 @@ public class HsrEndGameApplicationService : BaseAttachmentApplicationService
         }
 
         var tasks = nonNull
-            .SelectMany(x => x.Node1!.Avatars.Concat(x.Node2!.Avatars))
+            .SelectMany(x => (x.Node1?.Avatars ?? []).Concat(x.Node2?.Avatars ?? []).Concat(x.Node3?.Avatars ?? []))
             .DistinctBy(x => x.Id)
             .Select(x => m_ImageUpdaterService.UpdateImageAsync(x.ToImageData(), ImageProcessors.AvatarProcessor, cancellationToken));
         var buffTasks = challengeData.AllFloorDetail.Where(x => !x.IsFast)
-            .SelectMany(x => new List<HsrEndBuff> { x.Node1!.Buff, x.Node2!.Buff })
+            .SelectMany(x => new List<HsrEndBuff?> { x.Node1?.Buff, x.Node2?.Buff, x.Node3?.Buff })
+            .OfType<HsrEndBuff>()
             .DistinctBy(x => x.Id)
             .Select(x =>
                 m_ImageUpdaterService.UpdateImageAsync(x.ToImageData(),

--- a/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrEndGameApplicationService.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrEndGameApplicationService.cs
@@ -132,11 +132,12 @@ public class HsrEndGameApplicationService : BaseAttachmentApplicationService
         }
 
         var tasks = challengeData.AllFloorDetail
+            .Where(x => !x.IsFast)
             .SelectMany(x => (x.Node1?.Avatars ?? []).Concat(x.Node2?.Avatars ?? []).Concat(x.Node3?.Avatars ?? []))
             .DistinctBy(x => x.Id)
             .Select(x => m_ImageUpdaterService.UpdateImageAsync(x.ToImageData(), ImageProcessors.AvatarProcessor, cancellationToken));
         var buffTasks = challengeData.AllFloorDetail.Where(x => !x.IsFast)
-            .SelectMany(x => new List<HsrEndBuff?> { x.Node1?.Buff, x.Node2?.Buff, x.Node3?.Buff })
+            .SelectMany(x => new HsrEndBuff?[] { x.Node1?.Buff, x.Node2?.Buff, x.Node3?.Buff })
             .OfType<HsrEndBuff>()
             .DistinctBy(x => x.Id)
             .Select(x =>

--- a/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrEndGameApplicationService.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrEndGameApplicationService.cs
@@ -102,8 +102,7 @@ public class HsrEndGameApplicationService : BaseAttachmentApplicationService
                 isEphemeral: true);
         }
 
-        var nonNull = challengeData.AllFloorDetail.Where(x => x is { Node1: not null, Node2: not null }).ToList();
-        if (nonNull.Count == 0)
+        if (challengeData.AllFloorDetail.All(x => x is { Node1: null, Node2: null, Node3: null }))
         {
             Logger.LogInformation(LogMessage.NoClearRecords, mode.GetString(), context.UserId,
                 profile.GameUid);
@@ -132,7 +131,7 @@ public class HsrEndGameApplicationService : BaseAttachmentApplicationService
                 true);
         }
 
-        var tasks = nonNull
+        var tasks = challengeData.AllFloorDetail
             .SelectMany(x => (x.Node1?.Avatars ?? []).Concat(x.Node2?.Avatars ?? []).Concat(x.Node3?.Avatars ?? []))
             .DistinctBy(x => x.Id)
             .Select(x => m_ImageUpdaterService.UpdateImageAsync(x.ToImageData(), ImageProcessors.AvatarProcessor, cancellationToken));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced end-game data collection for avatars and buffs by retrieving information from all available sources with improved null-safety handling, ensuring more complete and reliable data availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->