### PR TITLE
Make DSGenerator thread-safe by using Random.Shared

### DIFF
--- a/MehrakBot/Common/Mehrak.GameApi.Tests/Shared/DSGeneratorTests.cs
+++ b/MehrakBot/Common/Mehrak.GameApi.Tests/Shared/DSGeneratorTests.cs
@@ -1,0 +1,32 @@
+﻿using System.Text.RegularExpressions;
+using Mehrak.GameApi.Shared;
+
+namespace Mehrak.GameApi.Tests.Shared;
+
+[TestFixture]
+[Parallelizable(ParallelScope.Self)]
+[FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+public class DSGeneratorTests
+{
+    private static readonly Regex DsFormatRegex = new(@"^\d+,[A-Za-z0-9]{6},[0-9a-f]{32}$", RegexOptions.Compiled);
+
+    [Test]
+    public void GenerateDS_ReturnsExpectedFormat()
+    {
+        var ds = DSGenerator.GenerateDS();
+
+        Assert.That(ds, Does.Match(DsFormatRegex));
+    }
+
+    [Test]
+    public void GenerateDS_ConcurrentCalls_DoNotThrow()
+    {
+        var tasks = Enumerable.Range(0, 200)
+            .Select(_ => Task.Run(() => DSGenerator.GenerateDS()));
+
+        var results = Task.WhenAll(tasks).GetAwaiter().GetResult();
+
+        Assert.That(results, Has.Length.EqualTo(200));
+        Assert.That(results, Has.All.Matches(DsFormatRegex));
+    }
+}

--- a/MehrakBot/Common/Mehrak.GameApi/Shared/DSGenerator.cs
+++ b/MehrakBot/Common/Mehrak.GameApi/Shared/DSGenerator.cs
@@ -11,7 +11,6 @@ public static class DSGenerator
 {
     private const string Salt = "6s25p5ox5y14umn1p61aqyyvbvvl3lrt";
     private const string Characters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-    private static readonly Random Random = new();
 
     public static string GenerateDS()
     {
@@ -20,7 +19,7 @@ public static class DSGenerator
 
         // Generate 6 random characters
         StringBuilder randomStr = new();
-        for (var i = 0; i < 6; i++) randomStr.Append(Characters[Random.Next(Characters.Length)]);
+        for (var i = 0; i < 6; i++) randomStr.Append(Characters[Random.Shared.Next(Characters.Length)]);
 
         // Create hash input
         var hashInput = $"salt={Salt}&t={timestamp}&r={randomStr}";


### PR DESCRIPTION
Remove the shared mutable private static readonly Random field and replace its usage with the thread-safe Random.Shared singleton. This prevents IndexOutOfRangeException corruption when GenerateDS() is called concurrently from the command dispatcher.

Added concurrency regression test (200 parallel calls) and format validation test to guard against future regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Introduced comprehensive test coverage for the DS generation functionality, including validation of output format correctness and verification of reliable operation under concurrent load scenarios with multiple simultaneous requests.

* **Refactor**
  * Optimized the DS generation implementation to enhance overall consistency and reliability of operations through improved internal mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->