### PR TITLE
Clean up m_CurrentRequests on auth modal timeout

### DIFF
--- a/MehrakBot/Services/Bot/Mehrak.Bot.Tests/Auth/AuthenticationMiddlewareServiceTests.cs
+++ b/MehrakBot/Services/Bot/Mehrak.Bot.Tests/Auth/AuthenticationMiddlewareServiceTests.cs
@@ -419,6 +419,7 @@ public class AuthenticationMiddlewareServiceTests
     }
 
     [Test]
+    [MaxTime(15000)]
     public async Task GetAuthenticationAsync_WhenModalTimesOut_ClearsCurrentRequests()
     {
         // Arrange

--- a/MehrakBot/Services/Bot/Mehrak.Bot.Tests/Auth/AuthenticationMiddlewareServiceTests.cs
+++ b/MehrakBot/Services/Bot/Mehrak.Bot.Tests/Auth/AuthenticationMiddlewareServiceTests.cs
@@ -418,6 +418,59 @@ public class AuthenticationMiddlewareServiceTests
         });
     }
 
+    [Test]
+    public async Task GetAuthenticationAsync_WhenModalTimesOut_ClearsCurrentRequests()
+    {
+        // Arrange
+        using var discordHelper = new DiscordTestHelper();
+        discordHelper.SetupRequestCapture();
+
+        var mockContext = new Mock<IInteractionContext>();
+        var interaction = discordHelper.CreateModalInteraction(TestUserId);
+        mockContext.SetupGet(x => x.Interaction).Returns(() => interaction);
+
+        var encryptedToken = "encrypted-token-for-timeout-test";
+
+        InitializeService(context =>
+        {
+            context.Users.Add(BuildUserModel(TestUserId, TestLtUid, encryptedToken));
+        });
+
+        m_MockCacheService
+            .Setup(x => x.GetAsync<string>(It.IsAny<string>()))
+            .ReturnsAsync((string?)null);
+
+        var request = new AuthenticationRequest(mockContext.Object, TestProfileId);
+
+        // Shorten timeout to avoid real 1-minute wait
+        var prop = typeof(AuthenticationMiddlewareService)
+            .GetProperty("TimeoutMinutes", BindingFlags.NonPublic | BindingFlags.Instance);
+        prop?.SetValue(m_Service, 0.1f);
+
+        // Act
+        var authTask = m_Service.GetAuthenticationAsync(request);
+
+        // Wait for the GUID to appear in m_CurrentRequests
+        var guid = await WaitForAuthenticationGuidAsync(m_Service);
+
+        // Wait for timeout
+        var result = await authTask;
+
+        // Assert - authentication should have timed out
+        Assert.That(result.Status, Is.EqualTo(AuthStatus.Timeout));
+
+        // Assert - late NotifyAuthenticate should be rejected (marker was cleaned up)
+        var lateResponse = new AuthenticationResponse(TestUserId, guid, "some-passphrase", mockContext.Object);
+        Assert.That(m_Service.NotifyAuthenticate(lateResponse), Is.False,
+            "NotifyAuthenticate should return false for a GUID whose timeout has expired");
+
+        // Assert - m_CurrentRequests should be empty
+        var field = typeof(AuthenticationMiddlewareService)
+            .GetField("m_CurrentRequests", BindingFlags.Instance | BindingFlags.NonPublic);
+        var dictionary = (ConcurrentDictionary<string, byte>)field!.GetValue(m_Service)!;
+        Assert.That(dictionary, Is.Empty, "m_CurrentRequests should be empty after timeout cleanup");
+    }
+
     #endregion
 
     #region AuthenticationRequest Tests

--- a/MehrakBot/Services/Bot/Mehrak.Bot/Shared/Services/AuthenticationMiddlewareService.cs
+++ b/MehrakBot/Services/Bot/Mehrak.Bot/Shared/Services/AuthenticationMiddlewareService.cs
@@ -178,6 +178,7 @@ public class AuthenticationMiddlewareService : IAuthenticationMiddlewareService
         }
         finally
         {
+            m_NotifiedRequests.TryRemove(guid, out _);
             m_CurrentRequests.TryRemove(guid, out _);
         }
     }

--- a/MehrakBot/Services/Bot/Mehrak.Bot/Shared/Services/AuthenticationMiddlewareService.cs
+++ b/MehrakBot/Services/Bot/Mehrak.Bot/Shared/Services/AuthenticationMiddlewareService.cs
@@ -168,7 +168,6 @@ public class AuthenticationMiddlewareService : IAuthenticationMiddlewareService
                 await Task.Delay(100, token);
             }
 
-            m_CurrentRequests.TryRemove(guid, out _);
             m_Logger.LogDebug("Authentication response dequeued. Guid={Guid}", guid);
             return response;
         }
@@ -176,6 +175,10 @@ public class AuthenticationMiddlewareService : IAuthenticationMiddlewareService
         {
             m_Logger.LogDebug("WaitForAuthenticationAsync canceled. Guid={Guid}", guid);
             return null;
+        }
+        finally
+        {
+            m_CurrentRequests.TryRemove(guid, out _);
         }
     }
 }


### PR DESCRIPTION
Move m_CurrentRequests.TryRemove into a finally block in WaitForAuthenticationAsync so the pending-request marker is always removed — whether the modal is answered (success), times out (cancellation), or encounters an unexpected exception.

Previously only the success path removed the marker, causing unbounded growth of m_CurrentRequests from abandoned auth modals.

Added regression test that verifies the marker is cleared on timeout by asserting a late NotifyAuthenticate is rejected and the dictionary is empty.