### PR TITLE
Bounded parallelism for multi character cards

### DIFF
--- a/MehrakBot/Common/Mehrak.Infrastructure/InfrastructureServiceCollectionExtension.cs
+++ b/MehrakBot/Common/Mehrak.Infrastructure/InfrastructureServiceCollectionExtension.cs
@@ -48,6 +48,8 @@ public static class InfrastructureServiceCollectionExtension
             options.UseNpgsql(sp.GetRequiredService<IOptions<PgConfig>>().Value.ConnectionString));
         services.AddDbContext<RelicDbContext>((sp, options) =>
             options.UseNpgsql(sp.GetRequiredService<IOptions<PgConfig>>().Value.ConnectionString));
+        services.AddDbContextFactory<RelicDbContext>((sp, options) =>
+            options.UseNpgsql(sp.GetRequiredService<IOptions<PgConfig>>().Value.ConnectionString));
         services.AddDbContext<DocumentationDbContext>((sp, options) =>
             options.UseNpgsql(sp.GetRequiredService<IOptions<PgConfig>>().Value.ConnectionString));
         services.AddDbContext<ReleaseNoteDbContext>((sp, options) =>

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Genshin/Character/GenshinCharacterApplicationServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Genshin/Character/GenshinCharacterApplicationServiceTests.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Mehrak.Application.Genshin.Character;
 using Mehrak.Application.Shared.Abstractions;
+using Mehrak.Application.Shared.Models;
 using Mehrak.Application.Tests.TestUtils;
 using Mehrak.Domain.Cache;
 using Mehrak.Domain.Card;
@@ -27,6 +28,7 @@ using Mehrak.Infrastructure.User.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 
 #endregion
@@ -1508,6 +1510,7 @@ public class GenshinCharacterApplicationServiceTests
             attachmentStorageMock.Object,
             portraitConfigMock.Object,
             Mock.Of<IUserPortraitService>(),
+            Options.Create(new CommandDispatcherConfig()),
             loggerMock.Object);
 
         return (service, characterApiMock, characterCacheMock, aliasServiceMock, wikiApiMock, imageRepositoryMock, imageUpdaterMock,
@@ -1585,6 +1588,7 @@ public class GenshinCharacterApplicationServiceTests
             attachmentStorageMock.Object,
             portraitConfigMock.Object,
             Mock.Of<IUserPortraitService>(),
+            Options.Create(new CommandDispatcherConfig()),
             loggerMock.Object);
 
         return (service, characterApiMock, characterCacheMock, wikiApiMock, imageRepositoryMock, gameRoleApiMock,
@@ -1665,6 +1669,7 @@ public class GenshinCharacterApplicationServiceTests
             attachmentStorageMock.Object,
             Mock.Of<ICharacterPortraitConfigService>(),
             Mock.Of<IUserPortraitService>(),
+            Options.Create(new CommandDispatcherConfig()),
             Mock.Of<ILogger<GenshinCharacterApplicationService>>());
 
         return (service, storedAttachments, userContext);

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Hsr/Character/HsrCharacterApplicationServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Hsr/Character/HsrCharacterApplicationServiceTests.cs
@@ -1331,6 +1331,9 @@ public class HsrCharacterApplicationServiceTests
 
         var userContext = m_DbFactory1.CreateDbContext<UserDbContext>();
         var relicContext = m_DbFactory2.CreateDbContext<RelicDbContext>();
+        var relicContextFactoryMock = new Mock<IDbContextFactory<RelicDbContext>>();
+        relicContextFactoryMock.Setup(x => x.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => m_DbFactory2.CreateDbContext<RelicDbContext>());
 
         var service = new HsrCharacterApplicationService(
             cardServiceMock.Object,
@@ -1343,7 +1346,7 @@ public class HsrCharacterApplicationServiceTests
             metricsMock.Object,
             gameRoleApiMock.Object,
             userContext,
-            relicContext,
+            relicContextFactoryMock.Object,
             attachmentStorageMock.Object,
             portraitConfigMock.Object,
             portraitServiceMock.Object,
@@ -1371,6 +1374,9 @@ public class HsrCharacterApplicationServiceTests
     {
         var userContext = m_DbFactory1.CreateDbContext<UserDbContext>();
         var relicContext = m_DbFactory2.CreateDbContext<RelicDbContext>();
+        var relicContextFactoryMock = new Mock<IDbContextFactory<RelicDbContext>>();
+        relicContextFactoryMock.Setup(x => x.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => m_DbFactory2.CreateDbContext<RelicDbContext>());
 
         var cardService = new HsrCharacterCardService(
             S3TestHelper.Instance.ImageRepository,
@@ -1428,7 +1434,7 @@ public class HsrCharacterApplicationServiceTests
             metricsMock.Object,
             gameRoleApiMock.Object,
             userContext,
-            relicContext,
+            relicContextFactoryMock.Object,
             attachmentStorageMock.Object,
             portraitConfigMock.Object,
             Mock.Of<IUserPortraitService>(),
@@ -1450,6 +1456,9 @@ public class HsrCharacterApplicationServiceTests
 
         var userContext = m_DbFactory1.CreateDbContext<UserDbContext>();
         var relicContext = m_DbFactory2.CreateDbContext<RelicDbContext>();
+        var relicContextFactoryMock = new Mock<IDbContextFactory<RelicDbContext>>();
+        relicContextFactoryMock.Setup(x => x.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => m_DbFactory2.CreateDbContext<RelicDbContext>());
 
         var cardService = new HsrCharacterCardService(
             S3TestHelper.Instance.ImageRepository,
@@ -1519,7 +1528,7 @@ public class HsrCharacterApplicationServiceTests
             metricsMock.Object,
             gameRoleApiService,
             userContext,
-            relicContext,
+            relicContextFactoryMock.Object,
             attachmentStorageMock.Object,
             Mock.Of<ICharacterPortraitConfigService>(),
             Mock.Of<IUserPortraitService>(),

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Hsr/Character/HsrCharacterApplicationServiceTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Hsr/Character/HsrCharacterApplicationServiceTests.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Mehrak.Application.Hsr.Character;
 using Mehrak.Application.Shared.Abstractions;
+using Mehrak.Application.Shared.Models;
 using Mehrak.Application.Tests.TestUtils;
 using Mehrak.Domain.Cache;
 using Mehrak.Domain.Card;
@@ -30,6 +31,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 
 #endregion
@@ -1345,6 +1347,7 @@ public class HsrCharacterApplicationServiceTests
             attachmentStorageMock.Object,
             portraitConfigMock.Object,
             portraitServiceMock.Object,
+            Options.Create(new CommandDispatcherConfig()),
             loggerMock.Object);
 
         return (service, characterApiMock, characterCacheMock, aliasServiceMock, wikiApiMock, imageRepositoryMock, imageUpdaterMock,
@@ -1429,6 +1432,7 @@ public class HsrCharacterApplicationServiceTests
             attachmentStorageMock.Object,
             portraitConfigMock.Object,
             Mock.Of<IUserPortraitService>(),
+            Options.Create(new CommandDispatcherConfig()),
             loggerMock.Object);
 
 
@@ -1519,6 +1523,7 @@ public class HsrCharacterApplicationServiceTests
             attachmentStorageMock.Object,
             Mock.Of<ICharacterPortraitConfigService>(),
             Mock.Of<IUserPortraitService>(),
+            Options.Create(new CommandDispatcherConfig()),
             Mock.Of<ILogger<HsrCharacterApplicationService>>());
 
 

--- a/MehrakBot/Services/Application/Mehrak.Application.Tests/Shared/Services/CharacterBatchProcessorTests.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application.Tests/Shared/Services/CharacterBatchProcessorTests.cs
@@ -1,0 +1,106 @@
+﻿#region
+
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Mehrak.Application.Shared.Services;
+using Mehrak.Domain.Shared.Enums;
+using Mehrak.Domain.Shared.Models;
+using NUnit.Framework;
+
+#endregion
+
+namespace Mehrak.Application.Tests.Shared.Services;
+
+[Parallelizable(ParallelScope.Self)]
+[FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+public class CharacterBatchProcessorTests
+{
+    [Test]
+    public async Task ProcessAsync_PreservesOutputOrder()
+    {
+        var items = Enumerable.Range(0, 6).ToList();
+
+        var (results, timedOut) = await CharacterBatchProcessor.ProcessAsync(
+            items,
+            (item, ct) => Task.FromResult(Result<string>.Success(item.ToString())),
+            maxDegreeOfParallelism: 4,
+            CancellationToken.None);
+
+        Assert.That(timedOut, Is.False);
+        Assert.That(results.Count, Is.EqualTo(6));
+        for (var i = 0; i < 6; i++)
+        {
+            Assert.That(results[i].Data, Is.EqualTo(i.ToString()));
+        }
+    }
+
+    [Test]
+    public async Task ProcessAsync_RespectsMaxDegreeOfParallelism()
+    {
+        var items = Enumerable.Range(0, 10).ToList();
+        var peakCount = 0;
+        var currentCount = 0;
+        var lockObj = new object();
+
+        var (results, timedOut) = await CharacterBatchProcessor.ProcessAsync(
+            items,
+            async (item, ct) =>
+            {
+                var local = Interlocked.Increment(ref currentCount);
+                lock (lockObj)
+                {
+                    if (local > peakCount) peakCount = local;
+                }
+                await Task.Delay(50, ct);
+                Interlocked.Decrement(ref currentCount);
+                return Result<string>.Success(item.ToString());
+            },
+            maxDegreeOfParallelism: 2,
+            CancellationToken.None);
+
+        Assert.That(timedOut, Is.False);
+        Assert.That(results.Count, Is.EqualTo(10));
+        Assert.That(peakCount, Is.LessThanOrEqualTo(2));
+    }
+
+    [Test]
+    public async Task ProcessAsync_StopsOnTimeout_AndSetsTimedOut()
+    {
+        var processed = new ConcurrentBag<int>();
+        var items = Enumerable.Range(0, 10).ToList();
+
+        var (results, timedOut) = await CharacterBatchProcessor.ProcessAsync(
+            items,
+            (item, ct) =>
+            {
+                processed.Add(item);
+                if (item == 3)
+                    return Task.FromResult(Result<string>.Failure(StatusCode.Timeout, "timed out"));
+                return Task.FromResult(Result<string>.Success(item.ToString()));
+            },
+            maxDegreeOfParallelism: 2,
+            CancellationToken.None);
+
+        Assert.That(timedOut, Is.True);
+    }
+
+    [Test]
+    public async Task ProcessAsync_DegreeClampedToOne_NeverDeadlocks()
+    {
+        var items = Enumerable.Range(0, 5).ToList();
+
+        var (results, timedOut) = await CharacterBatchProcessor.ProcessAsync(
+            items,
+            (item, ct) => Task.FromResult(Result<string>.Success(item.ToString())),
+            maxDegreeOfParallelism: 0,
+            CancellationToken.None);
+
+        Assert.That(timedOut, Is.False);
+        Assert.That(results.Count, Is.EqualTo(5));
+        for (var i = 0; i < 5; i++)
+        {
+            Assert.That(results[i].Data, Is.EqualTo(i.ToString()));
+        }
+    }
+}

--- a/MehrakBot/Services/Application/Mehrak.Application/Genshin/Character/GenshinCharacterApplicationService.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Genshin/Character/GenshinCharacterApplicationService.cs
@@ -5,6 +5,7 @@ using System.Text.Json.Nodes;
 using Mehrak.Application.Genshin.Extensions;
 using Mehrak.Application.Shared.Abstractions;
 using Mehrak.Application.Shared.Builders;
+using Mehrak.Application.Shared.Models;
 using Mehrak.Application.Shared.Renderers.Extensions;
 using Mehrak.Application.Shared.Services;
 using Mehrak.Application.Shared.Services.Types;
@@ -23,6 +24,7 @@ using Mehrak.GameApi.GameRole;
 using Mehrak.GameApi.Genshin.Types;
 using Mehrak.GameApi.Wiki;
 using Mehrak.Infrastructure.User;
+using Microsoft.Extensions.Options;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Processing;
 
@@ -48,6 +50,7 @@ internal class GenshinCharacterApplicationService : BaseAttachmentApplicationSer
     private readonly ICharacterStatService m_CharacterStatService;
     private readonly ICharacterPortraitConfigService m_PortraitConfigService;
     private readonly IUserPortraitService m_UserPortraitService;
+    private readonly IOptions<CommandDispatcherConfig> m_DispatcherConfig;
 
 
     protected override string CommandName => "Genshin Character";
@@ -67,6 +70,7 @@ internal class GenshinCharacterApplicationService : BaseAttachmentApplicationSer
         IAttachmentStorageService attachmentStorage,
         ICharacterPortraitConfigService portraitConfigService,
         IUserPortraitService userPortraitService,
+        IOptions<CommandDispatcherConfig> dispatcherConfig,
         ILogger<GenshinCharacterApplicationService> logger)
         : base(gameRoleApi, userContext, attachmentStorage, logger)
     {
@@ -81,6 +85,7 @@ internal class GenshinCharacterApplicationService : BaseAttachmentApplicationSer
         m_CharacterStatService = characterStatService;
         m_PortraitConfigService = portraitConfigService;
         m_UserPortraitService = userPortraitService;
+        m_DispatcherConfig = dispatcherConfig;
     }
 
     protected override async Task<CommandResult> ExecuteCommandAsync(IApplicationContext context, CancellationToken cancellationToken = default)
@@ -182,21 +187,26 @@ internal class GenshinCharacterApplicationService : BaseAttachmentApplicationSer
 
         List<string> attachments = [];
 
-        foreach (var charData in characterInfo.Data.List)
+        var (results, timedOut) = await CharacterBatchProcessor.ProcessAsync(
+            characterInfo.Data.List,
+            (charData, ct) => ProcessCharacterAsync(context, server, profile, charData,
+                characterInfo.Data.AvatarWiki, characterInfo.Data.WeaponWiki, ct),
+            m_DispatcherConfig.Value.MaxCharacterParallelism,
+            cancellationToken);
+
+        if (timedOut)
+            return CommandResult.Failure(CommandFailureReason.Timeout, ResponseMessage.TimeoutError);
+
+        for (var i = 0; i < results.Count; i++)
         {
-            var result = await ProcessCharacterAsync(context, server, profile, charData,
-                characterInfo.Data.AvatarWiki, characterInfo.Data.WeaponWiki, cancellationToken);
+            var result = results[i];
             if (result.IsSuccess)
             {
                 attachments.Add(result.Data);
             }
-            else if (result.StatusCode == StatusCode.Timeout)
-            {
-                return CommandResult.Failure(CommandFailureReason.Timeout, ResponseMessage.TimeoutError);
-            }
             else
             {
-                failureMessages.Add($"{charData.Base.Name}: {result.ErrorMessage}");
+                failureMessages.Add($"{characterInfo.Data.List[i].Base.Name}: {result.ErrorMessage}");
             }
         }
 

--- a/MehrakBot/Services/Application/Mehrak.Application/Hsr/Character/HsrCharacterApplicationService.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Hsr/Character/HsrCharacterApplicationService.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Mehrak.Application.Shared.Abstractions;
 using Mehrak.Application.Shared.Builders;
+using Mehrak.Application.Shared.Models;
 using Mehrak.Application.Shared.Services;
 using Mehrak.Application.Shared.Services.Types;
 using Mehrak.Application.Shared.Utility;
@@ -24,6 +25,7 @@ using Mehrak.GameApi.Wiki;
 using Mehrak.Infrastructure.Relic;
 using Mehrak.Infrastructure.User;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 
 #endregion
 
@@ -47,6 +49,7 @@ public class HsrCharacterApplicationService : BaseAttachmentApplicationService
     private readonly RelicDbContext m_RelicContext;
     private readonly ICharacterPortraitConfigService m_PortraitConfigService;
     private readonly IUserPortraitService m_UserPortraitService;
+    private readonly IOptions<CommandDispatcherConfig> m_DispatcherConfig;
 
 
     protected override string CommandName => "HSR Character";
@@ -66,6 +69,7 @@ public class HsrCharacterApplicationService : BaseAttachmentApplicationService
         IAttachmentStorageService attachmentStorageService,
         ICharacterPortraitConfigService portraitConfigService,
         IUserPortraitService userPortraitService,
+        IOptions<CommandDispatcherConfig> dispatcherConfig,
         ILogger<HsrCharacterApplicationService> logger) : base(gameRoleApi, userContext, attachmentStorageService, logger)
     {
         m_CardService = cardService;
@@ -79,6 +83,7 @@ public class HsrCharacterApplicationService : BaseAttachmentApplicationService
         m_RelicContext = relicContext;
         m_PortraitConfigService = portraitConfigService;
         m_UserPortraitService = userPortraitService;
+        m_DispatcherConfig = dispatcherConfig;
     }
 
     protected override async Task<CommandResult> ExecuteCommandAsync(IApplicationContext context, CancellationToken cancellationToken = default)
@@ -164,21 +169,27 @@ public class HsrCharacterApplicationService : BaseAttachmentApplicationService
 
         List<string> attachments = [];
 
-        foreach (var charData in validCharacters.Values)
+        var charList = validCharacters.Values.ToList();
+        var (results, timedOut) = await CharacterBatchProcessor.ProcessAsync(
+            charList,
+            (charData, ct) => ProcessCharacterAsync(context, server, profile, charData,
+                characterList.RelicWiki, characterList.EquipWiki, ct),
+            m_DispatcherConfig.Value.MaxCharacterParallelism,
+            cancellationToken);
+
+        if (timedOut)
+            return CommandResult.Failure(CommandFailureReason.Timeout, ResponseMessage.TimeoutError);
+
+        for (var i = 0; i < results.Count; i++)
         {
-            var result = await ProcessCharacterAsync(context, server, profile, charData,
-                characterList.RelicWiki, characterList.EquipWiki, cancellationToken);
+            var result = results[i];
             if (result.IsSuccess)
             {
                 attachments.Add(result.Data);
             }
-            else if (result.StatusCode == StatusCode.Timeout)
-            {
-                return CommandResult.Failure(CommandFailureReason.Timeout, ResponseMessage.TimeoutError);
-            }
             else
             {
-                failureMessages.Add($"{charData.Name}: {result.ErrorMessage}");
+                failureMessages.Add($"{charList[i].Name}: {result.ErrorMessage}");
             }
         }
 

--- a/MehrakBot/Services/Application/Mehrak.Application/Hsr/Character/HsrCharacterApplicationService.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Hsr/Character/HsrCharacterApplicationService.cs
@@ -26,6 +26,7 @@ using Mehrak.Infrastructure.Relic;
 using Mehrak.Infrastructure.User;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
+using Npgsql;
 
 #endregion
 
@@ -46,7 +47,7 @@ public class HsrCharacterApplicationService : BaseAttachmentApplicationService
         m_CharacterApi;
 
     private readonly IApplicationMetrics m_MetricsService;
-    private readonly RelicDbContext m_RelicContext;
+    private readonly IDbContextFactory<RelicDbContext> m_RelicContextFactory;
     private readonly ICharacterPortraitConfigService m_PortraitConfigService;
     private readonly IUserPortraitService m_UserPortraitService;
     private readonly IOptions<CommandDispatcherConfig> m_DispatcherConfig;
@@ -65,7 +66,7 @@ public class HsrCharacterApplicationService : BaseAttachmentApplicationService
         IApplicationMetrics metricsService,
         IApiService<GameProfileDto, GameRoleApiContext> gameRoleApi,
         UserDbContext userContext,
-        RelicDbContext relicContext,
+        IDbContextFactory<RelicDbContext> relicContextFactory,
         IAttachmentStorageService attachmentStorageService,
         ICharacterPortraitConfigService portraitConfigService,
         IUserPortraitService userPortraitService,
@@ -80,7 +81,7 @@ public class HsrCharacterApplicationService : BaseAttachmentApplicationService
         m_AliasService = aliasService;
         m_CharacterApi = characterApi;
         m_MetricsService = metricsService;
-        m_RelicContext = relicContext;
+        m_RelicContextFactory = relicContextFactory;
         m_PortraitConfigService = portraitConfigService;
         m_UserPortraitService = userPortraitService;
         m_DispatcherConfig = dispatcherConfig;
@@ -431,24 +432,44 @@ public class HsrCharacterApplicationService : BaseAttachmentApplicationService
     }
     private async Task AddSetName(int setId, string setName)
     {
-        try
+        const int maxRetries = 3;
+        for (var attempt = 1; attempt <= maxRetries; attempt++)
         {
-            var existing = await m_RelicContext.HsrRelics.AsNoTracking().FirstOrDefaultAsync(x => x.SetId == setId);
-            if (existing == null)
+            try
             {
-                var entity = new HsrRelicModel { SetId = setId, SetName = setName };
-                m_RelicContext.HsrRelics.Add(entity);
-                await m_RelicContext.SaveChangesAsync();
-                Logger.LogInformation("Inserted relic set mapping: setId {SetId} -> {SetName}", setId, setName);
+                await using var relicContext = await m_RelicContextFactory.CreateDbContextAsync();
+                var existing = await relicContext.HsrRelics.AsNoTracking().FirstOrDefaultAsync(x => x.SetId == setId);
+                if (existing == null)
+                {
+                    var entity = new HsrRelicModel { SetId = setId, SetName = setName };
+                    relicContext.HsrRelics.Add(entity);
+                    await relicContext.SaveChangesAsync();
+                    Logger.LogInformation("Inserted relic set mapping: setId {SetId} -> {SetName}", setId, setName);
+                }
+                else
+                {
+                    Logger.LogDebug("Relic set mapping for setId {SetId} : {SetName} already exists; skipping overwrite", setId, setName);
+                }
+                return;
             }
-            else
+            catch (DbUpdateException e) when (e.InnerException is PostgresException pgEx
+                                              && pgEx.SqlState is "23505" or "40001" or "57014")
             {
-                Logger.LogDebug("Relic set mapping for setId {SetId} : {SetName} already exists; skipping overwrite", setId, setName);
+                // 23505 = unique_violation (already inserted by concurrent request)
+                // 40001 = serialization_failure, 57014 = query_canceled — retriable
+                Logger.LogWarning(e, "Retriable DB error inserting relic set {Attempt}/{MaxRetries}: {SetId}", attempt, maxRetries, setId);
+                if (attempt == maxRetries)
+                {
+                    Logger.LogWarning(e, "Failed to insert relic set after {MaxRetries} attempts: {SetId}, {SetName}", maxRetries, setId, setName);
+                    return;
+                }
+                await Task.Delay(100 * attempt);
             }
-        }
-        catch (DbUpdateException e)
-        {
-            Logger.LogWarning(e, "An error occurred while inserting relic {SetId}, {SetName}", setId, setName);
+            catch (DbUpdateException e)
+            {
+                Logger.LogWarning(e, "Non-retriable DB error inserting relic {SetId}, {SetName}", setId, setName);
+                return;
+            }
         }
     }
 }

--- a/MehrakBot/Services/Application/Mehrak.Application/Shared/Models/CommandDispatcherConfig.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Shared/Models/CommandDispatcherConfig.cs
@@ -3,4 +3,13 @@
 public class CommandDispatcherConfig
 {
     public int MaxConcurrency { get; set; } = 10;
+
+    /// <summary>
+    /// Max number of characters processed concurrently within a single
+    /// multi-character command. Caps how much of the dispatcher's global
+    /// concurrency budget one user's request can consume. Default 2 keeps a
+    /// 4-character request from monopolizing workers while still cutting
+    /// wall-clock time roughly in half.
+    /// </summary>
+    public int MaxCharacterParallelism { get; set; } = 2;
 }

--- a/MehrakBot/Services/Application/Mehrak.Application/Shared/Services/CharacterBatchProcessor.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Shared/Services/CharacterBatchProcessor.cs
@@ -1,0 +1,39 @@
+﻿using Mehrak.Domain.Shared.Enums;
+using Mehrak.Domain.Shared.Models;
+
+namespace Mehrak.Application.Shared.Services;
+
+internal static class CharacterBatchProcessor
+{
+    internal static async Task<(IReadOnlyList<Result<string>> Results, bool TimedOut)> ProcessAsync<T>(
+        IReadOnlyList<T> items,
+        Func<T, CancellationToken, Task<Result<string>>> processAsync,
+        int maxDegreeOfParallelism,
+        CancellationToken cancellationToken)
+    {
+        var degree = Math.Max(1, maxDegreeOfParallelism);
+        var results = new Result<string>[items.Count];
+        using var semaphore = new SemaphoreSlim(degree);
+        var timedOut = false;
+
+        var tasks = items.Select(async (item, index) =>
+        {
+            await semaphore.WaitAsync(cancellationToken);
+            try
+            {
+                if (timedOut) return;
+                var result = await processAsync(item, cancellationToken);
+                results[index] = result;
+                if (result.StatusCode == StatusCode.Timeout)
+                    timedOut = true;
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+        });
+        await Task.WhenAll(tasks);
+
+        return (results, timedOut);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-character processing is now handled in parallel batches for improved throughput.
  * Added a configurable “MaxCharacterParallelism” setting (default: 2) to cap per-request character concurrency.
* **Bug Fixes**
  * Batch processing now preserves output order while enforcing the configured parallelism limit.
  * Timeout failures now short-circuit the batch reliably and mark operations as timed out.
  * Improved robustness when parallelism is set to 0 to prevent deadlocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->