### PR TITLE
Add Redis-backed passphrase attempt rate limiter

### DIFF
--- a/MehrakBot/Common/Mehrak.Infrastructure.Tests/Shared/PassphraseAttemptRateLimiterTests.cs
+++ b/MehrakBot/Common/Mehrak.Infrastructure.Tests/Shared/PassphraseAttemptRateLimiterTests.cs
@@ -1,0 +1,105 @@
+using Mehrak.Infrastructure.Shared;
+using Moq;
+using StackExchange.Redis;
+
+namespace Mehrak.Infrastructure.Tests.Shared;
+
+[TestFixture]
+[Parallelizable(ParallelScope.Self)]
+[FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+public class PassphraseAttemptRateLimiterTests
+{
+    private Mock<IConnectionMultiplexer> m_MockRedis;
+    private Mock<IDatabase> m_MockDatabase;
+    private PassphraseAttemptRateLimiter m_Limiter;
+
+    [SetUp]
+    public void SetUp()
+    {
+        m_MockRedis = new Mock<IConnectionMultiplexer>();
+        m_MockDatabase = new Mock<IDatabase>();
+        m_MockRedis.Setup(r => r.GetDatabase(It.IsAny<int>(), It.IsAny<object?>()))
+            .Returns(m_MockDatabase.Object);
+        m_Limiter = new PassphraseAttemptRateLimiter(m_MockRedis.Object);
+    }
+
+    [Test]
+    public async Task IsBlockedAsync_UnderLimit_ReturnsFalse()
+    {
+        // Arrange
+        const ulong userId = 123456789;
+        m_MockDatabase.Setup(d => d.ScriptEvaluateAsync(
+            It.IsAny<string>(),
+            It.IsAny<RedisKey[]>(),
+            It.IsAny<RedisValue[]>(),
+            It.IsAny<CommandFlags>()))
+            .ReturnsAsync(RedisResult.Create(0, ResultType.Integer));
+
+        // Act
+        var result = await m_Limiter.IsBlockedAsync(userId);
+
+        // Assert
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public async Task IsBlockedAsync_AtLimit_ReturnsTrue()
+    {
+        // Arrange
+        const ulong userId = 123456789;
+        m_MockDatabase.Setup(d => d.ScriptEvaluateAsync(
+            It.IsAny<string>(),
+            It.IsAny<RedisKey[]>(),
+            It.IsAny<RedisValue[]>(),
+            It.IsAny<CommandFlags>()))
+            .ReturnsAsync(RedisResult.Create(1, ResultType.Integer));
+
+        // Act
+        var result = await m_Limiter.IsBlockedAsync(userId);
+
+        // Assert
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public async Task RecordFailureAsync_CallsScriptEvaluate()
+    {
+        // Arrange
+        const ulong userId = 123456789;
+        m_MockDatabase.Setup(d => d.ScriptEvaluateAsync(
+            It.IsAny<string>(),
+            It.IsAny<RedisKey[]>(),
+            It.IsAny<RedisValue[]>(),
+            It.IsAny<CommandFlags>()))
+            .ReturnsAsync(RedisResult.Create(1, ResultType.Integer));
+
+        // Act
+        await m_Limiter.RecordFailureAsync(userId);
+
+        // Assert
+        m_MockDatabase.Verify(d => d.ScriptEvaluateAsync(
+            It.IsAny<string>(),
+            It.IsAny<RedisKey[]>(),
+            It.IsAny<RedisValue[]>(),
+            It.IsAny<CommandFlags>()), Times.Once);
+    }
+
+    [Test]
+    public async Task GetRemainingAttemptsAsync_ReturnsCorrectCount()
+    {
+        // Arrange
+        const ulong userId = 123456789;
+        m_MockDatabase.Setup(d => d.ScriptEvaluateAsync(
+            It.IsAny<string>(),
+            It.IsAny<RedisKey[]>(),
+            It.IsAny<RedisValue[]>(),
+            It.IsAny<CommandFlags>()))
+            .ReturnsAsync(RedisResult.Create(3, ResultType.Integer));
+
+        // Act
+        var result = await m_Limiter.GetRemainingAttemptsAsync(userId);
+
+        // Assert
+        Assert.That(result, Is.EqualTo(2));
+    }
+}

--- a/MehrakBot/Common/Mehrak.Infrastructure/InfrastructureServiceCollectionExtension.cs
+++ b/MehrakBot/Common/Mehrak.Infrastructure/InfrastructureServiceCollectionExtension.cs
@@ -103,6 +103,7 @@ public static class InfrastructureServiceCollectionExtension
 
         services.AddSingleton<IUserPortraitService, UserPortraitService>();
         services.AddSingleton<IPortraitUploadRateLimitService, PortraitUploadRateLimitService>();
+        services.AddSingleton<IPassphraseAttemptRateLimiter, PassphraseAttemptRateLimiter>();
 
         services.AddSingleton<IEncryptionService, CookieEncryptionService>();
 

--- a/MehrakBot/Common/Mehrak.Infrastructure/Shared/PassphraseAttemptRateLimiter.cs
+++ b/MehrakBot/Common/Mehrak.Infrastructure/Shared/PassphraseAttemptRateLimiter.cs
@@ -1,0 +1,94 @@
+using StackExchange.Redis;
+
+namespace Mehrak.Infrastructure.Shared;
+
+public interface IPassphraseAttemptRateLimiter
+{
+    Task<bool> IsBlockedAsync(ulong discordUserId, CancellationToken ct = default);
+    Task RecordFailureAsync(ulong discordUserId, CancellationToken ct = default);
+    Task<int> GetRemainingAttemptsAsync(ulong discordUserId, CancellationToken ct = default);
+}
+
+internal class PassphraseAttemptRateLimiter : IPassphraseAttemptRateLimiter
+{
+    private const int MaxAttempts = 5;
+    private static readonly TimeSpan Window = TimeSpan.FromMinutes(15);
+    private const string KeyPrefix = "passphrase_fail:";
+
+    private readonly IConnectionMultiplexer m_Redis;
+
+    public PassphraseAttemptRateLimiter(IConnectionMultiplexer redis)
+    {
+        m_Redis = redis;
+    }
+
+    public async Task<bool> IsBlockedAsync(ulong discordUserId, CancellationToken ct = default)
+    {
+        var db = m_Redis.GetDatabase();
+        var key = new RedisKey($"{KeyPrefix}{discordUserId}");
+        var now = DateTimeOffset.UtcNow;
+        var windowStart = now - Window;
+
+        var script = @"
+            local key = KEYS[1]
+            local window_start = tonumber(ARGV[1])
+            local max = tonumber(ARGV[2])
+            redis.call('ZREMRANGEBYSCORE', key, '-inf', window_start)
+            local count = redis.call('ZCARD', key)
+            if count >= max then
+                return 1
+            end
+            return 0";
+
+        var result = await db.ScriptEvaluateAsync(
+            script,
+            [key],
+            [(RedisValue)windowStart.ToUnixTimeMilliseconds().ToString(), MaxAttempts]);
+
+        return (int)result == 1;
+    }
+
+    public async Task RecordFailureAsync(ulong discordUserId, CancellationToken ct = default)
+    {
+        var db = m_Redis.GetDatabase();
+        var key = new RedisKey($"{KeyPrefix}{discordUserId}");
+        var now = DateTimeOffset.UtcNow;
+        var windowStart = now - Window;
+
+        var script = @"
+            local key = KEYS[1]
+            local window_start = tonumber(ARGV[1])
+            local now = ARGV[2]
+            redis.call('ZREMRANGEBYSCORE', key, '-inf', window_start)
+            redis.call('ZADD', key, now, now)
+            redis.call('EXPIRE', key, 900)";
+
+        await db.ScriptEvaluateAsync(
+            script,
+            [key],
+            [(RedisValue)windowStart.ToUnixTimeMilliseconds().ToString(), (RedisValue)now.ToUnixTimeMilliseconds().ToString()]);
+    }
+
+    public async Task<int> GetRemainingAttemptsAsync(ulong discordUserId, CancellationToken ct = default)
+    {
+        var db = m_Redis.GetDatabase();
+        var key = new RedisKey($"{KeyPrefix}{discordUserId}");
+        var now = DateTimeOffset.UtcNow;
+        var windowStart = now - Window;
+
+        var script = @"
+            local key = KEYS[1]
+            local window_start = tonumber(ARGV[1])
+            redis.call('ZREMRANGEBYSCORE', key, '-inf', window_start)
+            local count = redis.call('ZCARD', key)
+            return count";
+
+        var result = await db.ScriptEvaluateAsync(
+            script,
+            [key],
+            [(RedisValue)windowStart.ToUnixTimeMilliseconds().ToString()]);
+
+        var used = (int)result;
+        return Math.Max(0, MaxAttempts - used);
+    }
+}

--- a/MehrakBot/Services/Bot/Mehrak.Bot.Tests/Auth/AuthenticationMiddlewareServiceConcurrencyTests.cs
+++ b/MehrakBot/Services/Bot/Mehrak.Bot.Tests/Auth/AuthenticationMiddlewareServiceConcurrencyTests.cs
@@ -100,7 +100,8 @@ public partial class AuthenticationMiddlewareServiceConcurrencyTests
             m_MockCacheService.Object,
             m_EncryptionService,
             m_DbFactory.ScopeFactory,
-            NullLogger<AuthenticationMiddlewareService>.Instance);
+            NullLogger<AuthenticationMiddlewareService>.Instance,
+            Mock.Of<IPassphraseAttemptRateLimiter>());
     }
 
     [TearDown]

--- a/MehrakBot/Services/Bot/Mehrak.Bot.Tests/Auth/AuthenticationMiddlewareServiceIntegrationTests.cs
+++ b/MehrakBot/Services/Bot/Mehrak.Bot.Tests/Auth/AuthenticationMiddlewareServiceIntegrationTests.cs
@@ -592,7 +592,8 @@ public partial class AuthenticationMiddlewareServiceIntegrationTests
             m_MockCacheService.Object,
             m_EncryptionService,
             m_DbFactory.ScopeFactory,
-            NullLogger<AuthenticationMiddlewareService>.Instance);
+            NullLogger<AuthenticationMiddlewareService>.Instance,
+            Mock.Of<IPassphraseAttemptRateLimiter>());
     }
 
     private static UserModel CreateUserModel(ulong userId, int profileId, ulong ltUid, string ltoken)

--- a/MehrakBot/Services/Bot/Mehrak.Bot.Tests/Auth/AuthenticationMiddlewareServiceTests.cs
+++ b/MehrakBot/Services/Bot/Mehrak.Bot.Tests/Auth/AuthenticationMiddlewareServiceTests.cs
@@ -11,6 +11,7 @@ using Mehrak.Domain.Cache;
 using Mehrak.Domain.Cache.Abstractions;
 using Mehrak.Domain.Shared.Services;
 using Mehrak.Domain.User.Models;
+using Mehrak.Infrastructure.Shared;
 using Mehrak.Infrastructure.User;
 using Mehrak.Infrastructure.User.Models;
 using Microsoft.Extensions.Logging;
@@ -533,7 +534,8 @@ public class AuthenticationMiddlewareServiceTests
             m_MockCacheService.Object,
             m_MockEncryptionService.Object,
             m_DbFactory.ScopeFactory,
-            m_MockLogger.Object);
+            m_MockLogger.Object,
+            Mock.Of<IPassphraseAttemptRateLimiter>());
     }
 
     private static UserModel BuildUserModel(ulong userId, ulong ltUid, string ltoken, int profileId = TestProfileId)

--- a/MehrakBot/Services/Bot/Mehrak.Bot/Shared/Services/AuthenticationMiddlewareService.cs
+++ b/MehrakBot/Services/Bot/Mehrak.Bot/Shared/Services/AuthenticationMiddlewareService.cs
@@ -7,6 +7,7 @@ using Mehrak.Bot.Shared.Modules;
 using Mehrak.Domain.Cache;
 using Mehrak.Domain.Shared.Services;
 using Mehrak.Domain.User.Models;
+using Mehrak.Infrastructure.Shared;
 using Mehrak.Infrastructure.User;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -24,6 +25,7 @@ public class AuthenticationMiddlewareService : IAuthenticationMiddlewareService
     private readonly IEncryptionService m_EncryptionService;
     private readonly IServiceScopeFactory m_ServiceScopeFactory;
     private readonly ILogger<AuthenticationMiddlewareService> m_Logger;
+    private readonly IPassphraseAttemptRateLimiter m_PassphraseLimiter;
     private readonly ConcurrentDictionary<string, AuthenticationResponse> m_NotifiedRequests = [];
     private readonly ConcurrentDictionary<string, byte> m_CurrentRequests = [];
 
@@ -33,12 +35,14 @@ public class AuthenticationMiddlewareService : IAuthenticationMiddlewareService
         ICacheService cacheService,
         IEncryptionService encryptionService,
         IServiceScopeFactory serviceScopeFactory,
-        ILogger<AuthenticationMiddlewareService> logger)
+        ILogger<AuthenticationMiddlewareService> logger,
+        IPassphraseAttemptRateLimiter passphraseLimiter)
     {
         m_CacheService = cacheService;
         m_EncryptionService = encryptionService;
         m_ServiceScopeFactory = serviceScopeFactory;
         m_Logger = logger;
+        m_PassphraseLimiter = passphraseLimiter;
     }
 
     public async Task<AuthenticationResult> GetAuthenticationAsync(AuthenticationRequest request)
@@ -116,6 +120,12 @@ public class AuthenticationMiddlewareService : IAuthenticationMiddlewareService
         await authResponse.Context.Interaction.SendResponseAsync(
             InteractionCallback.DeferredMessage(MessageFlags.Ephemeral));
 
+        if (await m_PassphraseLimiter.IsBlockedAsync(request.Context.Interaction.User.Id))
+        {
+            m_Logger.LogWarning("Rate limit exceeded for passphrase attempts by user {UserId}", request.Context.Interaction.User.Id);
+            return AuthenticationResult.Failure(authResponse.Context, "Too many incorrect attempts. Please try again later.");
+        }
+
         try
         {
             token = m_EncryptionService.Decrypt(profile.LToken, authResponse.Passphrase);
@@ -126,6 +136,7 @@ public class AuthenticationMiddlewareService : IAuthenticationMiddlewareService
         {
             m_Logger.LogWarning(e, "Incorrect passphrase provided. Guid={Guid}, UserId={UserId}", authResponse.Guid,
                 request.Context.Interaction.User.Id);
+            await m_PassphraseLimiter.RecordFailureAsync(request.Context.Interaction.User.Id);
             return AuthenticationResult.Failure(authResponse.Context, "Incorrect passphrase. Please try again");
         }
 

--- a/MehrakBot/Services/Dashboard/Mehrak.Dashboard/ProfileAuth/ProfileAuthenticationController.cs
+++ b/MehrakBot/Services/Dashboard/Mehrak.Dashboard/ProfileAuth/ProfileAuthenticationController.cs
@@ -49,6 +49,7 @@ public sealed class ProfileAuthenticationController : ControllerBase
             DashboardAuthStatus.NotFound => NotFound(new { error = result.Error ?? "Profile not found." }),
             DashboardAuthStatus.InvalidPassphrase => BadRequest(new { error = result.Error ?? "Invalid passphrase." }),
             DashboardAuthStatus.PassphraseRequired => BadRequest(new { error = "Passphrase is required." }),
+            DashboardAuthStatus.RateLimited => StatusCode(StatusCodes.Status429TooManyRequests, new { error = result.Error ?? "Too many attempts. Please try again later." }),
             _ => StatusCode(StatusCodes.Status500InternalServerError,
                 new { error = result.Error ?? "Unable to authenticate profile." })
         };

--- a/MehrakBot/Services/Dashboard/Mehrak.Dashboard/Shared/Auth/DashboardProfileAuthenticationService.cs
+++ b/MehrakBot/Services/Dashboard/Mehrak.Dashboard/Shared/Auth/DashboardProfileAuthenticationService.cs
@@ -2,6 +2,7 @@
 using Mehrak.Domain.Cache;
 using Mehrak.Domain.Shared.Services;
 using Mehrak.Domain.User.Models;
+using Mehrak.Infrastructure.Shared;
 using Mehrak.Infrastructure.User;
 using Microsoft.EntityFrameworkCore;
 
@@ -24,18 +25,21 @@ public class DashboardProfileAuthenticationService : IDashboardProfileAuthentica
     private readonly IEncryptionService m_EncryptionService;
     private readonly ICacheService m_CacheService;
     private readonly ILogger<DashboardProfileAuthenticationService> m_Logger;
+    private readonly IPassphraseAttemptRateLimiter m_PassphraseLimiter;
     private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(5);
 
     public DashboardProfileAuthenticationService(
         UserDbContext userRepository,
         IEncryptionService encryptionService,
         ICacheService cacheService,
-        ILogger<DashboardProfileAuthenticationService> logger)
+        ILogger<DashboardProfileAuthenticationService> logger,
+        IPassphraseAttemptRateLimiter passphraseLimiter)
     {
         m_UserRepository = userRepository;
         m_EncryptionService = encryptionService;
         m_CacheService = cacheService;
         m_Logger = logger;
+        m_PassphraseLimiter = passphraseLimiter;
     }
 
     public async Task<DashboardProfileAuthenticationResult> AuthenticateAsync(
@@ -97,6 +101,12 @@ public class DashboardProfileAuthenticationService : IDashboardProfileAuthentica
                 "Authentication required. Please provide your passphrase.");
         }
 
+        if (await m_PassphraseLimiter.IsBlockedAsync(discordUserId, ct))
+        {
+            m_Logger.LogWarning("Rate limit exceeded for passphrase attempts by user {UserId}", discordUserId);
+            return DashboardProfileAuthenticationResult.RateLimited("Too many incorrect attempts. Please try again later.");
+        }
+
         try
         {
             var decrypted = m_EncryptionService.Decrypt(profile.LToken, passphrase);
@@ -115,6 +125,7 @@ public class DashboardProfileAuthenticationService : IDashboardProfileAuthentica
         {
             m_Logger.LogWarning(ex, "Dashboard authentication failed due to invalid passphrase for user {UserId}",
                 discordUserId);
+            await m_PassphraseLimiter.RecordFailureAsync(discordUserId, ct);
             return DashboardProfileAuthenticationResult.InvalidPassphrase("Incorrect passphrase. Please try again.");
         }
     }
@@ -140,7 +151,8 @@ public enum DashboardAuthStatus
     NotFound,
     PassphraseRequired,
     InvalidPassphrase,
-    Failure
+    Failure,
+    RateLimited
 }
 
 public class DashboardProfileAuthenticationResult
@@ -177,6 +189,9 @@ public class DashboardProfileAuthenticationResult
 
     public static DashboardProfileAuthenticationResult InvalidPassphrase(string error) =>
         new(DashboardAuthStatus.InvalidPassphrase, error, null, 0, null);
+
+    public static DashboardProfileAuthenticationResult RateLimited(string error) =>
+        new(DashboardAuthStatus.RateLimited, error, null, 0, null);
 
     public static DashboardProfileAuthenticationResult Failure(string error) =>
         new(DashboardAuthStatus.Failure, error, null, 0, null);

--- a/MehrakBot/Services/Dashboard/Mehrak.Dashboard/Shared/Services/DashboardApplicationExecutorService.cs
+++ b/MehrakBot/Services/Dashboard/Mehrak.Dashboard/Shared/Services/DashboardApplicationExecutorService.cs
@@ -73,30 +73,20 @@ internal class DashboardApplicationExecutorService : IDashboardApplicationExecut
             .AuthenticateAsync(DiscordUserId, profileId, null, ct)
             .ConfigureAwait(false);
 
-        switch (authResult.Status)
+        return authResult.Status switch
         {
-            case DashboardAuthStatus.Success:
-                return await ExecuteApplicationAsync(authResult, ct).ConfigureAwait(false);
-            case DashboardAuthStatus.PassphraseRequired:
-                m_Logger.LogInformation(
-                    "Dashboard authentication cache miss for user {UserId}, profile {ProfileId}",
-                    DiscordUserId,
-                    profileId);
-                return DashboardApplicationExecutionResult.AuthenticationRequired(authResult.Error ??
-                    "Authentication expired. Please re-authenticate this profile.");
-            case DashboardAuthStatus.InvalidPassphrase:
-                return DashboardApplicationExecutionResult.AuthenticationFailed(authResult.Error ??
-                    "Invalid passphrase. Please try again.");
-            case DashboardAuthStatus.RateLimited:
-                return DashboardApplicationExecutionResult.Error(authResult.Error ??
-                    "Too many attempts. Please try again later.");
-            case DashboardAuthStatus.NotFound:
-                return DashboardApplicationExecutionResult.NotFound(authResult.Error ??
-                    "Requested profile could not be found.");
-            default:
-                return DashboardApplicationExecutionResult.Error(authResult.Error ??
-                    "Unable to complete authentication.");
-        }
+            DashboardAuthStatus.Success => await ExecuteApplicationAsync(authResult, ct).ConfigureAwait(false),
+            DashboardAuthStatus.PassphraseRequired => DashboardApplicationExecutionResult.AuthenticationRequired(authResult.Error ??
+                                "Authentication expired. Please re-authenticate this profile."),
+            DashboardAuthStatus.InvalidPassphrase => DashboardApplicationExecutionResult.AuthenticationFailed(authResult.Error ??
+                                "Invalid passphrase. Please try again."),
+            DashboardAuthStatus.RateLimited => DashboardApplicationExecutionResult.Error(authResult.Error ??
+                                "Too many attempts. Please try again later."),
+            DashboardAuthStatus.NotFound => DashboardApplicationExecutionResult.NotFound(authResult.Error ??
+                                "Requested profile could not be found."),
+            _ => DashboardApplicationExecutionResult.Error(authResult.Error ??
+                                "Unable to complete authentication."),
+        };
     }
 
     private async Task<DashboardApplicationExecutionResult> ExecuteApplicationAsync(
@@ -140,6 +130,7 @@ public enum DashboardExecutionStatus
     AuthenticationRequired,
     AuthenticationFailed,
     NotFound,
+    RateLimited,
     Error
 }
 
@@ -227,6 +218,11 @@ public sealed class DashboardApplicationExecutionResult
                 => new ObjectResult(new { error = ErrorMessage ?? "Requested resource was not found." })
                 {
                     StatusCode = StatusCodes.Status404NotFound
+                },
+            DashboardExecutionStatus.RateLimited
+                => new ObjectResult(new { error = ErrorMessage ?? "Too many attempts. Please try again later." })
+                {
+                    StatusCode = StatusCodes.Status429TooManyRequests
                 },
             _
                 => new ObjectResult(new { error = ErrorMessage ?? "Unable to execute command." })

--- a/MehrakBot/Services/Dashboard/Mehrak.Dashboard/Shared/Services/DashboardApplicationExecutorService.cs
+++ b/MehrakBot/Services/Dashboard/Mehrak.Dashboard/Shared/Services/DashboardApplicationExecutorService.cs
@@ -87,6 +87,9 @@ internal class DashboardApplicationExecutorService : IDashboardApplicationExecut
             case DashboardAuthStatus.InvalidPassphrase:
                 return DashboardApplicationExecutionResult.AuthenticationFailed(authResult.Error ??
                     "Invalid passphrase. Please try again.");
+            case DashboardAuthStatus.RateLimited:
+                return DashboardApplicationExecutionResult.Error(authResult.Error ??
+                    "Too many attempts. Please try again later.");
             case DashboardAuthStatus.NotFound:
                 return DashboardApplicationExecutionResult.NotFound(authResult.Error ??
                     "Requested profile could not be found.");

--- a/MehrakBot/Services/Dashboard/Mehrak.Dashboard/Shared/Services/DashboardApplicationExecutorService.cs
+++ b/MehrakBot/Services/Dashboard/Mehrak.Dashboard/Shared/Services/DashboardApplicationExecutorService.cs
@@ -80,7 +80,7 @@ internal class DashboardApplicationExecutorService : IDashboardApplicationExecut
                                 "Authentication expired. Please re-authenticate this profile."),
             DashboardAuthStatus.InvalidPassphrase => DashboardApplicationExecutionResult.AuthenticationFailed(authResult.Error ??
                                 "Invalid passphrase. Please try again."),
-            DashboardAuthStatus.RateLimited => DashboardApplicationExecutionResult.Error(authResult.Error ??
+            DashboardAuthStatus.RateLimited => DashboardApplicationExecutionResult.RateLimited(authResult.Error ??
                                 "Too many attempts. Please try again later."),
             DashboardAuthStatus.NotFound => DashboardApplicationExecutionResult.NotFound(authResult.Error ??
                                 "Requested profile could not be found."),
@@ -181,6 +181,11 @@ public sealed class DashboardApplicationExecutionResult
     public static DashboardApplicationExecutionResult NotFound(string message)
     {
         return new DashboardApplicationExecutionResult(DashboardExecutionStatus.NotFound, errorMessage: message);
+    }
+
+    public static DashboardApplicationExecutionResult RateLimited(string message)
+    {
+        return new DashboardApplicationExecutionResult(DashboardExecutionStatus.RateLimited, errorMessage: message);
     }
 
     public static DashboardApplicationExecutionResult Error(string message)


### PR DESCRIPTION
- Add IPassphraseAttemptRateLimiter with sliding-window Redis sorted-set (5 attempts / 15-min)
- Enforce in Bot AuthenticationMiddlewareService and Dashboard DashboardProfileAuthenticationService
- Map RateLimited to HTTP 429 in ProfileAuthenticationController
- Register as Singleton in InfrastructureServiceCollectionExtension
- Add 4 unit tests for the limiter
- Update existing auth tests with mock dependency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Passphrase authentication now includes Redis-backed rate limiting: users exceeding the maximum failed attempts in a 15-minute rolling window are temporarily blocked.
  * Dashboard authentication responses now surface rate limiting via HTTP 429 with a “too many attempts” error message.
* **Tests**
  * Added unit tests validating rate-limiter behavior (blocked/unblocked, remaining attempts, and failure recording).
  * Updated authentication-related tests to include the new rate-limiter dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->