### PR TITLE
Set inactive portrait

### DIFF
--- a/MehrakBot/Common/Mehrak.Domain/Character/IUserPortraitService.cs
+++ b/MehrakBot/Common/Mehrak.Domain/Character/IUserPortraitService.cs
@@ -12,6 +12,7 @@ public interface IUserPortraitService
     Task<UploadPortraitResult> UploadPortraitAsync(long discordUserId, Game game, string characterName, Stream imageStream, string sha256, string extension, CancellationToken ct = default);
     Task<bool> UpdatePortraitConfigAsync(long discordUserId, Guid uploadId, UserPortraitConfigDto config, CancellationToken ct = default);
     Task<bool> SetActivePortraitAsync(long discordUserId, Guid uploadId, CancellationToken ct = default);
+    Task<bool> SetInactivePortraitAsync(long discordUserId, Guid uploadId, CancellationToken ct = default);
     Task<bool> DeletePortraitAsync(long discordUserId, Guid uploadId, CancellationToken ct = default);
     Task<int> GetUploadCountAsync(long discordUserId, Game game, string characterName, CancellationToken ct = default);
 }

--- a/MehrakBot/Common/Mehrak.Infrastructure/Character/Services/UserPortraitService.cs
+++ b/MehrakBot/Common/Mehrak.Infrastructure/Character/Services/UserPortraitService.cs
@@ -329,6 +329,33 @@ internal class UserPortraitService : IUserPortraitService
         }
     }
 
+    public async Task<bool> SetInactivePortraitAsync(
+        long discordUserId, Guid uploadId, CancellationToken ct = default)
+    {
+        using var scope = m_ScopeFactory.CreateScope();
+        using var context = scope.ServiceProvider.GetRequiredService<CharacterDbContext>();
+
+        var entity = await context.UserPortraitUploads
+            .FirstOrDefaultAsync(u => u.Id == uploadId && u.DiscordUserId == discordUserId, ct);
+
+        if (entity == null)
+            return false;
+
+        entity.IsActive = false;
+        entity.UpdatedAtUtc = DateTime.UtcNow;
+
+        try
+        {
+            await context.SaveChangesAsync(ct);
+            return true;
+        }
+        catch (DbUpdateException e)
+        {
+            m_Logger.LogError(e, "Failed to deactivate portrait {UploadId}", uploadId);
+            return false;
+        }
+    }
+
     public async Task<bool> DeletePortraitAsync(long discordUserId, Guid uploadId, CancellationToken ct = default)
     {
         using var scope = m_ScopeFactory.CreateScope();

--- a/MehrakBot/Services/Dashboard/Mehrak.Dashboard/Character/UserPortraitsController.cs
+++ b/MehrakBot/Services/Dashboard/Mehrak.Dashboard/Character/UserPortraitsController.cs
@@ -220,6 +220,20 @@ public class UserPortraitsController : ControllerBase
         return NoContent();
     }
 
+    [HttpPatch("{id:guid}/inactive")]
+    public async Task<IActionResult> SetInactivePortrait(Guid id)
+    {
+        var discordUserId = GetDiscordUserId();
+        if (discordUserId == null)
+            return Unauthorized(new { error = "Invalid user identity." });
+
+        var success = await m_PortraitService.SetInactivePortraitAsync(discordUserId.Value, id, HttpContext.RequestAborted);
+        if (!success)
+            return NotFound(new { error = "Portrait not found." });
+
+        return NoContent();
+    }
+
     [HttpDelete("{id:guid}")]
     public async Task<IActionResult> DeletePortrait(Guid id)
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to mark user portraits as inactive. Users can now deactivate previously uploaded portraits through the dashboard without permanently deleting them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->