### PR TITLE
HSR Endgame card stage text overlaps score extra

### DIFF
--- a/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrEndGameCardServiceBase.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrEndGameCardServiceBase.cs
@@ -138,7 +138,7 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
 
                     var stageText = GetStageText(gameModeData, floorData, floorNumber);
 
-                    var starShift = floorData.ExtraStarNum > 0 ? floorData.ExtraStarNum * 50 : 0;
+                    var starShift = (floorData?.ExtraStarNum ?? 0) > 0 ? floorData!.ExtraStarNum * 50 : 0;
 
                     var scoreText = $"Score: {floorData?.TotalScore ?? 0}";
                     var scoreTextWidth = (int)TextMeasurer.MeasureBounds(scoreText, new TextOptions(Fonts.Normal)).Width;

--- a/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrEndGameCardServiceBase.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrEndGameCardServiceBase.cs
@@ -138,10 +138,12 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
 
                     var stageText = GetStageText(gameModeData, floorData, floorNumber);
 
+                    var starShift = floorData.ExtraStarNum > 0 ? floorData.ExtraStarNum * 50 : 0;
+
                     var scoreText = $"Score: {floorData?.TotalScore ?? 0}";
                     var scoreTextWidth = (int)TextMeasurer.MeasureBounds(scoreText, new TextOptions(Fonts.Normal)).Width;
                     var scoreExtrasWidth = GetScoreExtrasWidth(scoreText);
-                    var maxTextWidth = 880 - 40 - 15 - scoreTextWidth - scoreExtrasWidth - 150;
+                    var maxTextWidth = 880 - 40 - 15 - scoreTextWidth - scoreExtrasWidth - 150 - starShift;
                     var bounds = TextMeasurer.MeasureBounds(stageText, new TextOptions(Fonts.Normal));
                     canvas.DrawText(new RichTextOptions(bounds.Width >= maxTextWidth ? Fonts.Small : Fonts.Normal)
                     {
@@ -179,7 +181,6 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
                     var extraRoom = blobHeight - contentEndY;
                     var separator2Y = extraRoom > 0 && !floorData.IsTierce ? blobHeight / 2 : 335;
                     var separator3Y = 605;
-                    var starShift = floorData.ExtraStarNum > 0 ? floorData.ExtraStarNum * 50 : 0;
 
                     var node1Y = Math.Max(85, (65 + separator2Y) / 2 - 125);
                     var section2End = floorData.IsTierce ? separator3Y : blobHeight;

--- a/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrEndGameCardServiceBase.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrEndGameCardServiceBase.cs
@@ -138,7 +138,10 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
 
                     var stageText = GetStageText(gameModeData, floorData, floorNumber);
 
-                    var maxTextWidth = floorData?.ExtraStarNum > 0 ? 380 : 450;
+                    var scoreText = $"Score: {floorData?.TotalScore ?? 0}";
+                    var scoreTextWidth = (int)TextMeasurer.MeasureBounds(scoreText, new TextOptions(Fonts.Normal)).Width;
+                    var scoreExtrasWidth = GetScoreExtrasWidth(scoreText);
+                    var maxTextWidth = 880 - 40 - 15 - scoreTextWidth - scoreExtrasWidth - 150;
                     var bounds = TextMeasurer.MeasureBounds(stageText, new TextOptions(Fonts.Normal));
                     canvas.DrawText(new RichTextOptions(bounds.Width >= maxTextWidth ? Fonts.Small : Fonts.Normal)
                     {
@@ -228,7 +231,6 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
 
                     canvas.Draw(Pens.Solid(Color.White, 2f), new PathBuilder().AddLine(new PointF(xOffset + 720 - starShift, yOffset + 10),
                         new PointF(xOffset + 720 - starShift, yOffset + 55)).Build());
-                    var scoreText = $"Score: {floorData.TotalScore}";
                     canvas.DrawText(new RichTextOptions(Fonts.Normal)
                     {
                         Origin = new PointF(xOffset + 710 - starShift, yOffset + 34),
@@ -358,6 +360,8 @@ internal abstract class HsrEndGameCardServiceBase : CardServiceBase<HsrEndInform
 
     protected virtual void DrawNodeExtras(DrawingCanvas region, HsrEndNodeInformation nodeData)
     { }
+
+    protected virtual int GetScoreExtrasWidth(string scoreText) => 0;
 
     protected virtual void DrawScoreExtras(DrawingCanvas canvas, int xOffset, int yOffset,
         string scoreText, HsrEndFloorDetail floorData, HsrEndInformation gameModeData)

--- a/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrPureFictionCardService.cs
+++ b/MehrakBot/Services/Application/Mehrak.Application/Hsr/EndGame/HsrPureFictionCardService.cs
@@ -76,6 +76,12 @@ internal class HsrPureFictionCardService : HsrEndGameCardServiceBase
         return strBuilder.ToString();
     }
 
+    protected override int GetScoreExtrasWidth(string scoreText)
+    {
+        // ponytail: fixed layout — cycle icon at x=650, separator at x=695
+        return 45;
+    }
+
     protected override void DrawScoreExtras(DrawingCanvas canvas, int xOffset, int yOffset,
         string scoreText, HsrEndFloorDetail floorData, HsrEndInformation gameModeData)
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved score text rendering in end-game cards to be more reliable with null-safe handling and more precise spacing.

* **Refactor**
  * Refined horizontal space calculation for score extras in end-game results, including a Pure Fiction–specific layout adjustment for consistent alignment of score-related elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->